### PR TITLE
Reduce bundle size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,14 @@
         "exclude": ["transform-regenerator"]
       }
     ]
+  ],
+  "plugins": [
+    [
+      "component",
+      {
+        "libraryName": "element-ui",
+        "styleLibraryName": "theme-chalk"
+      }
+    ]
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -18,6 +18,7 @@
         "libraryName": "element-ui",
         "styleLibraryName": "theme-chalk"
       }
-    ]
+    ],
+    "@babel/plugin-syntax-dynamic-import"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@vue/eslint-config-standard": "3.0.0-rc.4",
     "@vue/test-utils": "^1.0.0-beta.20",
     "babel-core": "^7.0.0-0",
+    "babel-plugin-component": "^1.1.1",
     "chai": "^4.1.2",
     "chai-things": "^0.2.0",
     "inject-loader": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.54",
     "@babel/polyfill": "^7.0.0-beta.53",
     "@babel/preset-env": "^7.0.0-beta.53",
     "@vue/cli-plugin-babel": "3.0.0-rc.4",
@@ -45,6 +46,7 @@
     "babel-plugin-component": "^1.1.1",
     "chai": "^4.1.2",
     "chai-things": "^0.2.0",
+    "hard-source-webpack-plugin": "^0.11.2",
     "inject-loader": "^4.0.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "lint-staged": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "babel-plugin-component": "^1.1.1",
     "chai": "^4.1.2",
     "chai-things": "^0.2.0",
-    "hard-source-webpack-plugin": "^0.11.2",
     "inject-loader": "^4.0.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "lint-staged": "^7.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import _ from 'lodash'
+import debounce from 'lodash/debounce'
 import { mapState } from 'vuex'
 
 export default {
@@ -22,7 +22,7 @@ export default {
   },
 
   methods: {
-    showConnectionErrorMessage: _.debounce(function () {
+    showConnectionErrorMessage: debounce(function () {
       this.$message.error(`connection error: Please check IP address OR your internet connection`)
     }, 1000)
   }

--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -1,6 +1,6 @@
 <script>
 import { Line } from 'vue-chartjs'
-import { format } from 'date-fns'
+import format from 'date-fns/format'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
 export default {

--- a/src/components/Dashboard/Charts/LineChartTable.vue
+++ b/src/components/Dashboard/Charts/LineChartTable.vue
@@ -1,6 +1,6 @@
 <script>
 import { Line } from 'vue-chartjs'
-import { format } from 'date-fns'
+import format from 'date-fns/format'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
 export default {

--- a/src/components/Dashboard/DashboardChart.vue
+++ b/src/components/Dashboard/DashboardChart.vue
@@ -26,11 +26,11 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import LineChartTable from '@/components/Dashboard/Charts/LineChartTable'
+import { lazyComponent } from '@router'
 
 export default {
   components: {
-    LineChartTable
+    LineChartTable: lazyComponent('Dashboard/Charts/LineChartTable')
   },
   data () {
     return {

--- a/src/components/Dashboard/DashboardDonutChart.vue
+++ b/src/components/Dashboard/DashboardDonutChart.vue
@@ -23,12 +23,12 @@
 </template>
 
 <script>
-import DonutChart from '@/components/Dashboard/Charts/DonutChart'
+import { lazyComponent } from '@router'
 
 export default {
   name: 'dashboard-donut-chart',
   components: {
-    DonutChart
+    DonutChart: lazyComponent('Dashboard/Charts/DonutChart')
   },
   props: {
     portfolio: {

--- a/src/components/Dashboard/DashboardPage.vue
+++ b/src/components/Dashboard/DashboardPage.vue
@@ -30,20 +30,16 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import DashboardPortfolio from '@/components/Dashboard/DashboardPortfolio'
-import DashboardDonutChart from '@/components/Dashboard/DashboardDonutChart'
-import DashboardTable from '@/components/Dashboard/DashboardTable'
-import DashboardChart from '@/components/Dashboard/DashboardChart'
-import NoAssetsCard from '@/components/common/NoAssetsCard'
+import { lazyComponent } from '@router'
 
 export default {
   name: 'dashboard-page',
   components: {
-    DashboardPortfolio,
-    DashboardDonutChart,
-    DashboardTable,
-    DashboardChart,
-    NoAssetsCard
+    DashboardPortfolio: lazyComponent('Dashboard/DashboardPortfolio'),
+    DashboardDonutChart: lazyComponent('Dashboard/DashboardDonutChart'),
+    DashboardTable: lazyComponent('Dashboard/DashboardTable'),
+    DashboardChart: lazyComponent('Dashboard/DashboardChart'),
+    NoAssetsCard: lazyComponent('common/NoAssetsCard')
   },
   data () {
     return {}

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -31,14 +31,14 @@
 </template>
 
 <script>
-import LineChartPortfolio from '@/components/Dashboard/Charts/LineChartPortfolio'
+import { lazyComponent } from '@router'
 import numberFormat from '@/components/mixins/numberFormat'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
 export default {
   name: 'dashboard-portfolio',
   components: {
-    LineChartPortfolio
+    LineChartPortfolio: lazyComponent('Dashboard/Charts/LineChartPortfolio')
   },
   mixins: [
     numberFormat,

--- a/src/components/Dashboard/DashboardTable.vue
+++ b/src/components/Dashboard/DashboardTable.vue
@@ -44,7 +44,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import _ from 'lodash/collection'
+import includes from 'lodash/includes'
 import numberFormat from '@/components/mixins/numberFormat'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
@@ -70,8 +70,8 @@ export default {
     ]),
     filteredPortfolio () {
       return this.portfolio.filter(crypto => {
-        const isName = _.includes(crypto.name.toLowerCase(), this.filterInput.toLowerCase())
-        const isAsset = _.includes(crypto.asset.toLowerCase(), this.filterInput.toLowerCase())
+        const isName = includes(crypto.name.toLowerCase(), this.filterInput.toLowerCase())
+        const isAsset = includes(crypto.asset.toLowerCase(), this.filterInput.toLowerCase())
         return isName || isAsset
       })
     }

--- a/src/components/Wallets/WalletsPage.vue
+++ b/src/components/Wallets/WalletsPage.vue
@@ -21,14 +21,13 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import WalletMenuItem from '@/components/Wallets/WalletMenuItem'
-import NoAssetsCard from '@/components/common/NoAssetsCard'
+import { lazyComponent } from '@router'
 
 export default {
   name: 'wallets-page',
   components: {
-    WalletMenuItem,
-    NoAssetsCard
+    WalletMenuItem: lazyComponent('Wallets/WalletMenuItem'),
+    NoAssetsCard: lazyComponent('common/NoAssetsCard')
   },
 
   data () {

--- a/src/components/mixins/dateFormat.js
+++ b/src/components/mixins/dateFormat.js
@@ -3,7 +3,7 @@ import flatten from 'lodash/fp/flatten'
 import sortedUniq from 'lodash/fp/sortedUniq'
 import flow from 'lodash/fp/flow'
 import tz from 'timezones.json'
-import { format } from 'date-fns'
+import format from 'date-fns/format'
 
 const timezones = flow(map(t => t.utc), flatten, sortedUniq)(tz)
 

--- a/src/components/mixins/dateFormat.js
+++ b/src/components/mixins/dateFormat.js
@@ -1,12 +1,11 @@
-import _ from 'lodash'
+import map from 'lodash/fp/map'
+import flatten from 'lodash/fp/flatten'
+import sortedUniq from 'lodash/fp/sortedUniq'
+import flow from 'lodash/fp/flow'
 import tz from 'timezones.json'
 import { format } from 'date-fns'
 
-const timezones = _(tz)
-  .map(t => t.utc)
-  .flatten()
-  .sortedUniq()
-  .value()
+const timezones = flow(map(t => t.utc), flatten, sortedUniq)(tz)
 
 const offsetByZone = (zone) =>
   tz.find(t =>

--- a/src/main.js
+++ b/src/main.js
@@ -21,16 +21,67 @@ import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload'
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-import ElementUI from 'element-ui'
-import 'element-ui/lib/theme-chalk/index.css'
-import locale from 'element-ui/lib/locale/lang/en'
+import {
+  Dialog,
+  Menu,
+  MenuItem,
+  Input,
+  Radio,
+  RadioGroup,
+  Select,
+  Option,
+  Button,
+  Table,
+  TableColumn,
+  DatePicker,
+  Form,
+  FormItem,
+  Tag,
+  Row,
+  Col,
+  Upload,
+  Card,
+  Container,
+  Header,
+  Aside,
+  Main,
+  Loading,
+  MessageBox
+} from 'element-ui'
+import lang from 'element-ui/lib/locale/lang/en'
+import locale from 'element-ui/lib/locale'
 import 'cryptocoins-icons/webfont/cryptocoins.css'
+
+Vue.use(Dialog)
+Vue.use(Menu)
+Vue.use(MenuItem)
+Vue.use(Input)
+Vue.use(Radio)
+Vue.use(RadioGroup)
+Vue.use(Select)
+Vue.use(Option)
+Vue.use(Button)
+Vue.use(Table)
+Vue.use(TableColumn)
+Vue.use(DatePicker)
+Vue.use(Form)
+Vue.use(FormItem)
+Vue.use(Tag)
+Vue.use(Row)
+Vue.use(Col)
+Vue.use(Upload)
+Vue.use(Card)
+Vue.use(Container)
+Vue.use(Header)
+Vue.use(Aside)
+Vue.use(Main)
+Vue.use(Loading.directive)
+Vue.prototype.$alert = MessageBox.alert
+locale.use(lang)
 
 library.add(faCog, faChartLine, faWallet, faSignOutAlt, faFileInvoice, faExchangeAlt, faAngleDoubleDown, faAngleDoubleUp, faArrowRight, faDownload, faUpload)
 Vue.component('fa-icon', FontAwesomeIcon)
 
-// TODO: import only necessary components
-Vue.use(ElementUI, { locale })
 Vue.config.productionTip = false
 
 new Vue({

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,19 @@ import router from './router'
 import store from './store'
 
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCog, faChartLine, faWallet, faSignOutAlt, faFileInvoice, faExchangeAlt, faAngleDoubleDown, faAngleDoubleUp, faArrowRight, faDownload, faUpload } from '@fortawesome/free-solid-svg-icons'
+
+import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
+import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine'
+import { faWallet } from '@fortawesome/free-solid-svg-icons/faWallet'
+import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt'
+import { faFileInvoice } from '@fortawesome/free-solid-svg-icons/faFileInvoice'
+import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons/faExchangeAlt'
+import { faAngleDoubleDown } from '@fortawesome/free-solid-svg-icons/faAngleDoubleDown'
+import { faAngleDoubleUp } from '@fortawesome/free-solid-svg-icons/faAngleDoubleUp'
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight'
+import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload'
+import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload'
+
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 import ElementUI from 'element-ui'

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,7 @@ import {
   Aside,
   Main,
   Loading,
+  Message,
   MessageBox
 } from 'element-ui'
 import lang from 'element-ui/lib/locale/lang/en'
@@ -77,6 +78,7 @@ Vue.use(Aside)
 Vue.use(Main)
 Vue.use(Loading.directive)
 Vue.prototype.$alert = MessageBox.alert
+Vue.prototype.$message = Message
 locale.use(lang)
 
 library.add(faCog, faChartLine, faWallet, faSignOutAlt, faFileInvoice, faExchangeAlt, faAngleDoubleDown, faAngleDoubleUp, faArrowRight, faDownload, faUpload)

--- a/src/router.js
+++ b/src/router.js
@@ -2,87 +2,76 @@ import Vue from 'vue'
 import Router from 'vue-router'
 import irohaUtil from '@util/iroha-util'
 
-import Home from '@/components/Home'
-import DashboardPage from '@/components/Dashboard/DashboardPage'
-import WalletsPage from '@/components/Wallets/WalletsPage'
-import Wallet from '@/components/Wallets/Wallet'
-import SettlementsPage from '@/components/Settlements/SettlementsPage'
-import SettlementsIncoming from '@/components/Settlements/SettlementsIncoming'
-import SettlementsOutgoing from '@/components/Settlements/SettlementsOutgoing'
-import SettlementsHistory from '@/components/Settlements/SettlementsHistory'
-import ReportsPage from '@/components/Reports/ReportsPage'
-import Login from '@/components/Login'
-import Signup from '@/components/Signup'
-import SettingsPage from '@/components/Settings/SettingsPage'
-
 Vue.use(Router)
+
+export const lazyComponent = (name) => () => import(`@/components/${name}.vue`)
 
 const defaultRouter = new Router({
   mode: 'hash',
   routes: [
     {
       path: '/',
-      component: Home,
+      component: lazyComponent('Home'),
       children: [
         {
           path: '',
           name: 'dashboard',
-          component: DashboardPage
+          component: lazyComponent('Dashboard/DashboardPage')
         },
         {
           path: 'wallets',
           name: 'wallets',
-          component: WalletsPage,
+          component: lazyComponent('Wallets/WalletsPage'),
           children: [
             {
               path: ':walletId',
-              component: Wallet
+              component: lazyComponent('Wallets/Wallet')
             }
           ]
         },
         {
           path: 'settlements',
           name: 'settlements-page',
-          component: SettlementsPage,
+          component: lazyComponent('Settlements/SettlementsPage'),
           children: [
             {
               path: 'history',
               name: 'settlements-history',
-              component: SettlementsHistory
+              component: lazyComponent('Settlements/SettlementsHistory')
             },
             {
               path: 'incoming',
               name: 'settlements-incoming',
-              component: SettlementsIncoming
+              component: lazyComponent('Settlements/SettlementsIncoming')
             },
             {
               path: 'outgoing',
               name: 'settlements-outgoing',
-              component: SettlementsOutgoing
+              component: lazyComponent('Settlements/SettlementsOutgoing')
             }
           ]
         },
         {
           path: 'reports',
           name: 'reports',
-          component: ReportsPage
+          component: lazyComponent('Reports/ReportsPage')
         },
         {
           path: 'settings',
           name: 'settings',
-          component: SettingsPage
+          component: lazyComponent('Settings/SettingsPage')
         }
       ]
     },
     {
       path: '/login',
       name: 'login',
-      component: Login
+      component: lazyComponent('Login')
     },
     {
       path: '/signup',
       name: 'signup',
-      component: Signup
+      component: lazyComponent('Signup')
     },
     {
       path: '*',

--- a/src/store/Account.js
+++ b/src/store/Account.js
@@ -1,5 +1,9 @@
 import Vue from 'vue'
-import _ from 'lodash'
+import map from 'lodash/fp/map'
+import flatMap from 'lodash/fp/flatMap'
+import concat from 'lodash/fp/concat'
+import fromPairs from 'lodash/fp/fromPairs'
+import flow from 'lodash/fp/flow'
 import { grpc } from 'grpc-web-client'
 import irohaUtil from '@util/iroha-util'
 import notaryUtil from '@util/notary-util'
@@ -10,7 +14,14 @@ import { getTransferAssetsFrom, getSettlementsFrom } from '@util/store-util'
 //   1. to get asset's properties (e.g. color) which cannot be fetched from API.
 const DUMMY_ASSETS = require('@/mocks/wallets.json').wallets
 
-const types = _([
+const types = flow(
+  flatMap(x => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE']),
+  concat([
+    'RESET'
+  ]),
+  map(x => [x, x]),
+  fromPairs
+)([
   'SIGNUP',
   'LOGIN',
   'LOGOUT',
@@ -22,12 +33,7 @@ const types = _([
   'CREATE_SETTLEMENT',
   'ACCEPT_SETTLEMENT',
   'REJECT_SETTLEMENT'
-]).chain()
-  .flatMap(x => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE'])
-  .concat(['RESET'])
-  .map(x => [x, x])
-  .fromPairs()
-  .value()
+])
 
 function initialState () {
   return {

--- a/src/store/Settings.js
+++ b/src/store/Settings.js
@@ -74,7 +74,7 @@ const actions = {
     if (storage) {
       commit(types.LOAD_SETTINGS, storage)
     } else {
-      setItem('settings', omit(state, 'default'))
+      setItem('settings', omit('default')(state))
     }
   },
   updateSettingsViewFiat ({ commit }, fiat) {

--- a/src/store/Settings.js
+++ b/src/store/Settings.js
@@ -1,15 +1,20 @@
 import Vue from 'vue'
-import _ from 'lodash'
+import map from 'lodash/fp/map'
+import fromPairs from 'lodash/fp/fromPairs'
+import flow from 'lodash/fp/flow'
+import omit from 'lodash/fp/omit'
+import isEqual from 'lodash/fp/isEqual'
 import { getParsedItem, setParsedItem, setItem } from '@util/storage-util'
 
-const types = _([
+const types = flow(
+  map(x => [x, x]),
+  fromPairs
+)([
   'LOAD_SETTINGS',
   'UPDATE_SETTINGS_VIEW_FIAT',
   'UPDATE_SETTINGS_VIEW_CRYPTO',
   'UPDATE_SETTINGS_VIEW_TIMEZONE'
-]).map(x => [x, x])
-  .fromPairs()
-  .value()
+])
 
 function initialState () {
   return {
@@ -41,7 +46,7 @@ const getters = {
 
 const mutations = {
   [types.LOAD_SETTINGS] (state, storage) {
-    if (!_.isEqual(state, storage)) {
+    if (!isEqual(state, storage)) {
       Object.keys(state).map(key => {
         if (key !== 'default') {
           state[key] = storage[key]
@@ -69,7 +74,7 @@ const actions = {
     if (storage) {
       commit(types.LOAD_SETTINGS, storage)
     } else {
-      setItem('settings', _.omit(state, 'default'))
+      setItem('settings', omit(state, 'default'))
     }
   },
   updateSettingsViewFiat ({ commit }, fiat) {

--- a/src/store/Wallet.js
+++ b/src/store/Wallet.js
@@ -1,17 +1,21 @@
 import Vue from 'vue'
-import _ from 'lodash'
+import map from 'lodash/fp/map'
+import flatMap from 'lodash/fp/flatMap'
+import concat from 'lodash/fp/concat'
+import fromPairs from 'lodash/fp/fromPairs'
+import flow from 'lodash/fp/flow'
 import cryptoCompareUtil from '@util/cryptoApi-axios-util'
 
-const types = _([
-  'GET_CRYPTO_FULL_DATA'
-]).chain()
-  .flatMap(x => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE'])
-  .concat([
+const types = flow(
+  flatMap(x => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE']),
+  concat([
     'RESET'
-  ])
-  .map(x => [x, x])
-  .fromPairs()
-  .value()
+  ]),
+  map(x => [x, x]),
+  fromPairs
+)([
+  'GET_CRYPTO_FULL_DATA'
+])
 
 function initialState () {
   return {

--- a/src/util/storage-util.js
+++ b/src/util/storage-util.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import set from 'lodash/fp/set'
 
 const localStorage = global.localStorage || {
   setItem () {},
@@ -47,7 +47,7 @@ const getParsedItem = (key) => {
 const setParsedItem = (key, value) => {
   const path = key.split('.')
   const i = getParsedItem(path[0])
-  const v = _.set(i, path.slice(1), value)
+  const v = set(path.slice(1))(value)(i)
   setItem(path[0], v)
 }
 

--- a/src/util/store-util.js
+++ b/src/util/store-util.js
@@ -1,4 +1,9 @@
-import _ from 'lodash'
+import flow from 'lodash/fp/flow'
+import isEmpty from 'lodash/fp/isEmpty'
+import isEqual from 'lodash/fp/isEqual'
+import uniqWith from 'lodash/fp/uniqWith'
+import sortBy from 'lodash/fp/sortBy'
+import reverse from 'lodash/fp/reverse'
 import { amountToString } from './iroha-amount'
 
 // TODO: To be removed.
@@ -24,7 +29,7 @@ function findSettlementOfTransaction (settlements = [], transferAsset) {
 }
 
 export function getTransferAssetsFrom (transactions, accountId, settlements = []) {
-  if (_.isEmpty(transactions)) return []
+  if (isEmpty(transactions)) return []
 
   const transformed = []
 
@@ -79,18 +84,17 @@ export function getTransferAssetsFrom (transactions, accountId, settlements = []
     *
     * To avoid it, we uniq the transactions.
     */
-  return _(transformed)
-    .chain()
-    .uniqWith(_.isEqual)
-    .sortBy('date')
-    .reverse()
-    .value()
+  return flow(
+    uniqWith(isEqual),
+    sortBy('date'),
+    reverse
+  )(transformed)
 }
 
 // TODO: extract settlements from raw transactions and return
 // TODO: might be able to put together with getTransferAssetsFrom
 export function getSettlementsFrom (transactions) {
-  if (_.isEmpty(transactions)) return []
+  if (isEmpty(transactions)) return []
 
   return DUMMY_SETTLEMENTS
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const webpack = require('webpack')
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin')
 
 const rules = []
 
@@ -15,17 +16,20 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 module.exports = {
+  chainWebpack: config => {
+    config.resolve.alias
+      .set('@util', path.resolve(__dirname, 'src/util'))
+      .set('@router', path.resolve(__dirname, 'src/router.js'))
+    config.plugin('IgnorePlugin').use(webpack.IgnorePlugin, [/^\.\/locale$/, /moment$/])
+    config.plugin('HardSource').use(HardSourceWebpackPlugin)
+    config.plugin('html').tap(args => {
+      args[0].chunksSortMode = 'none'
+      return args
+    })
+  },
   configureWebpack: {
-    resolve: {
-      alias: {
-        '@util': path.resolve(__dirname, 'src/util')
-      }
-    },
     module: {
       rules: rules
-    },
-    plugins: [
-      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
-    ]
+    }
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const webpack = require('webpack')
 
 const rules = []
 
@@ -22,6 +23,9 @@ module.exports = {
     },
     module: {
       rules: rules
-    }
+    },
+    plugins: [
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
+    ]
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const webpack = require('webpack')
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin')
 
 const rules = []
 
@@ -21,7 +20,6 @@ module.exports = {
       .set('@util', path.resolve(__dirname, 'src/util'))
       .set('@router', path.resolve(__dirname, 'src/router.js'))
     config.plugin('IgnorePlugin').use(webpack.IgnorePlugin, [/^\.\/locale$/, /moment$/])
-    config.plugin('HardSource').use(HardSourceWebpackPlugin)
     config.plugin('html').tap(args => {
       args[0].chunksSortMode = 'none'
       return args

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,10 @@
   version "7.0.0-beta.53"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.53.tgz#d64458636ffc258b42714a9dd93aeb6f8b8cf3ed"
 
+"@babel/helper-plugin-utils@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.54.tgz#61d2a9a0f9a3e31838a458debb9eebd7bdd249b4"
+
 "@babel/helper-regex@7.0.0-beta.47":
   version "7.0.0-beta.47"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0-beta.47.tgz#b8e3b53132c4edbb04804242c02ffe4d60316971"
@@ -591,6 +595,12 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.47.tgz#ee964915014a687701ee8e15c289e31a7c899e60"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.47"
+
+"@babel/plugin-syntax-dynamic-import@^7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.54.tgz#c962627f4e1a15da6d0842306d421e7b1e52f587"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.54"
 
 "@babel/plugin-syntax-export-namespace-from@7.0.0-beta.47":
   version "7.0.0-beta.47"
@@ -1664,6 +1674,10 @@
     text-table "^0.2.0"
     webpack-log "^1.1.2"
 
+JSV@^4.0.x:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1794,6 +1808,10 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -2620,6 +2638,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -3498,6 +3524,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-indent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -4294,6 +4324,14 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-cache-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^3.0.0"
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -4310,6 +4348,12 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -4735,11 +4779,31 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
+hard-source-webpack-plugin@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.11.2.tgz#7b31c4f9192a319dfb04741a105066992890503a"
+  dependencies:
+    chalk "^2.4.1"
+    find-cache-dir "^2.0.0"
+    jsonlint "^1.6.3"
+    lodash "^4.15.0"
+    mkdirp "^0.5.1"
+    node-object-hash "^1.2.0"
+    pkg-dir "^3.0.0"
+    rimraf "^2.6.2"
+    tapable "^1.0.0-beta.5"
+    webpack-sources "^1.0.1"
+    write-json-file "^2.3.0"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -5362,6 +5426,10 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -5692,6 +5760,13 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonlint@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/jsonlint/-/jsonlint-1.6.3.tgz#cb5e31efc0b78291d0d862fbef05900adf212988"
+  dependencies:
+    JSV "^4.0.x"
+    nomnom "^1.5.x"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -5900,6 +5975,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
@@ -6065,7 +6147,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -6635,6 +6717,10 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
+node-object-hash@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-1.4.1.tgz#de968492e20c493b8bbc25ad2ee828265fd60934"
+
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -6683,6 +6769,13 @@ node-sass@^4.7.2:
 nodent-runtime@^3.0.3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/nodent-runtime/-/nodent-runtime-3.2.1.tgz#9e2755d85e39f764288f0d4752ebcfe3e541e00e"
+
+nomnom@^1.5.x:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -7023,11 +7116,23 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -7036,6 +7141,10 @@ p-map@^1.1.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 pac-proxy-agent@1:
   version "1.1.0"
@@ -7242,6 +7351,12 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
 
 please-upgrade-node@^3.0.2:
   version "3.1.1"
@@ -8490,6 +8605,12 @@ socks@~1.1.5:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
 
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
@@ -8756,6 +8877,10 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -8852,7 +8977,7 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tapable@^1.0.0:
+tapable@^1.0.0, tapable@^1.0.0-beta.5:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
@@ -9108,6 +9233,10 @@ uglifyjs-webpack-plugin@^1.2.4, uglifyjs-webpack-plugin@^1.2.7:
     uglify-es "^3.3.4"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -9595,6 +9724,25 @@ write-file-atomic@^1.1.4:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
+
+write-file-atomic@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write-json-file@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
+  dependencies:
+    detect-indent "^5.0.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    pify "^3.0.0"
+    sort-keys "^2.0.0"
+    write-file-atomic "^2.0.0"
 
 write@^0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,6 +238,13 @@
   dependencies:
     "@babel/types" "7.0.0-beta.53"
 
+"@babel/helper-module-imports@7.0.0-beta.35":
+  version "7.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.35.tgz#308e350e731752cdb4d0f058df1d704925c64e0a"
+  dependencies:
+    "@babel/types" "7.0.0-beta.35"
+    lodash "^4.2.0"
+
 "@babel/helper-module-imports@7.0.0-beta.47":
   version "7.0.0-beta.47"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.47.tgz#5af072029ffcfbece6ffbaf5d9984c75580f3f04"
@@ -1252,6 +1259,14 @@
     invariant "^2.2.0"
     lodash "^4.17.5"
 
+"@babel/types@7.0.0-beta.35":
+  version "7.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.35.tgz#cf933a9a9a38484ca724b335b88d83726d5ab960"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
@@ -2101,6 +2116,12 @@ babel-messages@^6.23.0:
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-component/-/babel-plugin-component-1.1.1.tgz#9b023a23ff5c9aae0fd56c5a18b9cab8c4d45eea"
+  dependencies:
+    "@babel/helper-module-imports" "7.0.0-beta.35"
 
 babel-plugin-dynamic-import-node@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,10 +1674,6 @@
     text-table "^0.2.0"
     webpack-log "^1.1.2"
 
-JSV@^4.0.x:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
-
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1808,10 +1804,6 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
-
-ansi-styles@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -2638,14 +2630,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
-  dependencies:
-    ansi-styles "~1.0.0"
-    has-color "~0.1.0"
-    strip-ansi "~0.1.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -3524,10 +3508,6 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-detect-indent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
-
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -4324,14 +4304,6 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
-find-cache-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
-  dependencies:
-    commondir "^1.0.1"
-    make-dir "^1.0.0"
-    pkg-dir "^3.0.0"
-
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -4348,12 +4320,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  dependencies:
-    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -4779,31 +4745,11 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
-hard-source-webpack-plugin@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.11.2.tgz#7b31c4f9192a319dfb04741a105066992890503a"
-  dependencies:
-    chalk "^2.4.1"
-    find-cache-dir "^2.0.0"
-    jsonlint "^1.6.3"
-    lodash "^4.15.0"
-    mkdirp "^0.5.1"
-    node-object-hash "^1.2.0"
-    pkg-dir "^3.0.0"
-    rimraf "^2.6.2"
-    tapable "^1.0.0-beta.5"
-    webpack-sources "^1.0.1"
-    write-json-file "^2.3.0"
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
-
-has-color@~0.1.0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -5426,10 +5372,6 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -5760,13 +5702,6 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonlint@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/jsonlint/-/jsonlint-1.6.3.tgz#cb5e31efc0b78291d0d862fbef05900adf212988"
-  dependencies:
-    JSV "^4.0.x"
-    nomnom "^1.5.x"
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -5975,13 +5910,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
-
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
@@ -6147,7 +6075,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -6717,10 +6645,6 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-object-hash@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-1.4.1.tgz#de968492e20c493b8bbc25ad2ee828265fd60934"
-
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -6769,13 +6693,6 @@ node-sass@^4.7.2:
 nodent-runtime@^3.0.3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/nodent-runtime/-/nodent-runtime-3.2.1.tgz#9e2755d85e39f764288f0d4752ebcfe3e541e00e"
-
-nomnom@^1.5.x:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
-  dependencies:
-    chalk "~0.4.0"
-    underscore "~1.6.0"
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -7116,23 +7033,11 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
-  dependencies:
-    p-try "^2.0.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  dependencies:
-    p-limit "^2.0.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -7141,10 +7046,6 @@ p-map@^1.1.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-
-p-try@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 pac-proxy-agent@1:
   version "1.1.0"
@@ -7351,12 +7252,6 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
-
-pkg-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
-  dependencies:
-    find-up "^3.0.0"
 
 please-upgrade-node@^3.0.2:
   version "3.1.1"
@@ -8605,12 +8500,6 @@ socks@~1.1.5:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
 
-sort-keys@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
-  dependencies:
-    is-plain-obj "^1.0.0"
-
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
@@ -8877,10 +8766,6 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
-
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -8977,7 +8862,7 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tapable@^1.0.0, tapable@^1.0.0-beta.5:
+tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
@@ -9233,10 +9118,6 @@ uglifyjs-webpack-plugin@^1.2.4, uglifyjs-webpack-plugin@^1.2.7:
     uglify-es "^3.3.4"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
-
-underscore@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -9724,25 +9605,6 @@ write-file-atomic@^1.1.4:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
-
-write-file-atomic@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
-
-write-json-file@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
-  dependencies:
-    detect-indent "^5.0.0"
-    graceful-fs "^4.1.2"
-    make-dir "^1.0.0"
-    pify "^3.0.0"
-    sort-keys "^2.0.0"
-    write-file-atomic "^2.0.0"
 
 write@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
# Description
### Bundle
#### Previous version
_Size_: 9.8 MB
![image](https://user-images.githubusercontent.com/16295803/43071147-7e41c352-8e7a-11e8-9560-3ce3a43b9c2c.png)

Download: [report.html.zip](https://github.com/d3ledger/back-office/files/2227909/report.html.zip)

#### Current version
_Size_: 8 MB
![image](https://user-images.githubusercontent.com/16295803/43200877-99190306-901f-11e8-8c45-2430a47c8445.png)

#### Works done
- [x] Import only required icons from `fortawesome` library. We should import icons one by one because this library don't work with tree-shaking currently. **(Size: 560 KB -> 85 KB)** 
- [x] ~Remove `chart.js` due to it's require `moment` library~. I suggest not to remove `chart.js` in

 this PR, because I can reduce size of the `moment` library. **(Size: 525 KB -> 125 KB)**
- [x] Reduce `element-ui` bundle size. **(Size: 1.41 MB -> 944 KB)**
- [x] Reduce `lodash` bundle size. As I read in this article - [Why using `_.chain` is a mistake.](https://medium.com/making-internets/why-using-chain-is-a-mistake-9bc1f80d51ba) I changed all `chains` with `flow`. **(Size: 689 KB -> 241 KB)**
- [x] Reduce `date-fns` **(Size: 170 KB  -> 34 KB)**
- [x] Added lazy loading for all components in the app. Now to import components please use `lazyComponent` from `routes.js` About lazy components you can read here - [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html#grouping-components-in-the-same-chunk) and [Lazy Loading Components with vue-cli 3](https://alligator.io/vuejs/lazy-loading-vue-cli-3-webpack/)
- [x] Simple webpack -> Chain webpack. Changed our webpack configuration from object to chaining. I guess it will improve readability of `vue.config.js` if it will grow. More about it - [Github - webpack-chain](https://github.com/mozilla-neutrino/webpack-chain)
#### Big parts
This is list of parts that still have big size
- `iroha-lib` - 4 MB
- `util\proto` - 430 KB
- `element-ui` - 944 KB
- `chart.js` - 345 KB
# How to check
1. `yarn` to install new packages.
2. `yarn build:more-memory --report` - to build production version with report.