### PR TITLE
Feature/reduce charts size

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "chart.js": "^2.7.2",
     "cryptocoins-icons": "^2.7.0",
     "date-fns": "^1.29.0",
+    "echarts": "^4.1.0",
     "element-ui": "^2.4.4",
     "file-saver": "^1.3.8",
     "grpc-web-client": "^0.6.2",
@@ -29,6 +30,7 @@
     "timezones.json": "^1.4.3",
     "vue": "^2.5.16",
     "vue-chartjs": "^3.3.2",
+    "vue-echarts-v3": "^1.0.19",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.1.1",
     "@fortawesome/vue-fontawesome": "^0.1.1",
     "axios": "^0.18.0",
-    "chart.js": "^2.7.2",
     "cryptocoins-icons": "^2.7.0",
     "date-fns": "^1.29.0",
     "echarts": "^4.1.0",
@@ -29,8 +28,7 @@
     "source-map-support": "^0.5.4",
     "timezones.json": "^1.4.3",
     "vue": "^2.5.16",
-    "vue-chartjs": "^3.3.2",
-    "vue-echarts-v3": "^1.0.19",
+    "vue-echarts": "^3.0.9",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"
   },

--- a/src/components/Dashboard/Charts/DonutChart.vue
+++ b/src/components/Dashboard/Charts/DonutChart.vue
@@ -1,8 +1,22 @@
-<script>
-import { Doughnut } from 'vue-chartjs'
+<template>
+  <div class="echarts">
+    <IEcharts
+      :option="chart"
+      :resizable="true"
+      @ready="onReady"
+    />
+  </div>
+</template>
 
+<script>
+import IEcharts from 'vue-echarts-v3/src/lite.js'
+import 'echarts/lib/chart/pie'
+import 'echarts/lib/component/tooltip'
 export default {
-  extends: Doughnut,
+  name: 'donut-chart',
+  components: {
+    IEcharts
+  },
   props: {
     data: {
       type: Array,
@@ -10,38 +24,61 @@ export default {
     }
   },
   data () {
-    return {}
+    return {
+      chart: {
+        tooltip: {
+          trigger: 'item',
+          formatter: '{b} <br/>{c}%'
+        },
+        series: [{
+          name: 'Portfolio percent',
+          type: 'pie',
+          radius: ['70%', '80%'],
+          avoidLabelOverlap: false,
+          label: {
+            normal: {
+              show: false,
+              position: 'center'
+            },
+            emphasis: {
+              show: true,
+              textStyle: {
+                fontSize: '30',
+                fontWeight: 'bold'
+              }
+            }
+          },
+          labelLine: {
+            normal: {
+              show: false
+            }
+          },
+          data: []
+        }]
+      }
+    }
   },
   watch: {
     data () {
-      this.updateChart()
+      this.onReady()
     }
   },
   methods: {
-    updateChart () {
-      this.renderChart({
-        labels: this.data.map(c => c.asset),
-        datasets: [{
-          data: this.data.map(c => c.percent.toFixed(2)),
-          backgroundColor: this.data.map(c => `#${c.color}`)
-        }]
-      }, {
-        responsive: true,
-        maintainAspectRatio: false,
-        legend: {
-          display: false
-        },
-        tooltips: {
-          callbacks: {
-            label: function (tooltipItem, data) {
-              const value = data.datasets[0].data[tooltipItem.index] || 0
-              const label = data.labels[tooltipItem.index] || ''
-              return `${label} - ${value}%`
-            }
-          }
+    onReady (instance, ECharts) {
+      this.chart.series[0].data = this.data.map(a => ({
+        value: a.percent.toFixed(2),
+        name: a.asset,
+        itemStyle: {
+          color: `#${a.color}`
         }
-      })
+      }))
     }
   }
 }
 </script>
+
+<style scoped>
+.echarts {
+  height: 190px
+}
+</style>

--- a/src/components/Dashboard/Charts/DonutChart.vue
+++ b/src/components/Dashboard/Charts/DonutChart.vue
@@ -1,22 +1,16 @@
 <template>
   <div class="echarts">
-    <IEcharts
-      :option="chart"
-      :resizable="true"
+    <ECharts
+      :options="chart"
+      :auto-resize="true"
       @ready="onReady"
     />
   </div>
 </template>
 
 <script>
-import IEcharts from 'vue-echarts-v3/src/lite.js'
-import 'echarts/lib/chart/pie'
-import 'echarts/lib/component/tooltip'
 export default {
   name: 'donut-chart',
-  components: {
-    IEcharts
-  },
   props: {
     data: {
       type: Array,
@@ -79,6 +73,7 @@ export default {
 
 <style scoped>
 .echarts {
+  width: 100%;
   height: 190px
 }
 </style>

--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -1,25 +1,19 @@
 <template>
   <div class="echarts">
-    <IEcharts
-      :option="chart"
-      :resizable="true"
+    <ECharts
+      :options="chart"
+      :auto-resize="true"
       @ready="onReady"
     />
   </div>
 </template>
 
 <script>
-import IEcharts from 'vue-echarts-v3/src/lite.js'
-import 'echarts/lib/chart/line'
-import 'echarts/lib/component/tooltip'
 import format from 'date-fns/format'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
 export default {
   name: 'line-chart-portfolio',
-  components: {
-    IEcharts
-  },
   props: {
     data: {
       type: Array,

--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -1,78 +1,84 @@
+<template>
+  <div class="echarts">
+    <IEcharts
+      :option="chart"
+      :resizable="true"
+      @ready="onReady"
+    />
+  </div>
+</template>
+
 <script>
-import { Line } from 'vue-chartjs'
+import IEcharts from 'vue-echarts-v3/src/lite.js'
+import 'echarts/lib/chart/line'
+import 'echarts/lib/component/tooltip'
 import format from 'date-fns/format'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
 export default {
-  extends: Line,
+  name: 'line-chart-portfolio',
+  components: {
+    IEcharts
+  },
   props: {
     data: {
       type: Array,
-      required: false
+      required: true
     }
   },
   mixins: [
     currencySymbol
   ],
+  data () {
+    return {
+      chart: {
+        grid: {
+          width: '104%',
+          height: '100%',
+          top: '0%',
+          left: '-2%'
+        },
+        tooltip: {
+          trigger: 'axis'
+        },
+        xAxis: {
+          show: false,
+          data: []
+        },
+        yAxis: {
+          show: false
+        },
+        series: [{
+          type: 'line',
+          symbol: 'none',
+          itemStyle: {
+            color: '#000000'
+          },
+          lineStyle: {
+            width: 1
+          },
+          areaStyle: {
+            color: '#fafafa'
+          },
+          data: []
+        }]
+      }
+    }
+  },
   watch: {
     data () {
-      this.updateChart()
+      this.onReady()
     }
   },
   methods: {
-    updateChart () {
-      const symbol = this.currencySymbol
-      let scales = {
-        xAxes: [{
-          gridLines: {
-            display: false,
-            drawTicks: false
-          },
-          ticks: {
-            display: false
-          }
-        }],
-        yAxes: [{
-          stacked: true,
-          gridLines: {
-            display: true,
-            drawTicks: false,
-            drawBorder: false
-          },
-          ticks: {
-            display: false
-          }
-        }]
+    onReady (instance, ECharts) {
+      this.chart.tooltip.formatter = data => {
+        const value = data[0].value
+        const date = data[0].axisValue
+        return `${date}<br/>${value.toFixed(2)} ${this.currencySymbol}`
       }
-
-      this.renderChart({
-        labels: this.data.map(i => this.convertDate(i.time)),
-        datasets: [{
-          bezierCurve: false,
-          lineTension: 0,
-          borderWidth: 1,
-          backgroundColor: '#fafafa',
-          borderColor: '#000000',
-          data: this.data.map(i => i.sum),
-          pointRadius: 0,
-          pointHitRadius: 10
-        }]
-      }, {
-        responsive: true,
-        maintainAspectRatio: false,
-        legend: {
-          display: false
-        },
-        tooltips: {
-          callbacks: {
-            label: function (tooltipItem, data) {
-              const value = data.datasets[0].data[tooltipItem.index] || 0
-              return `${value.toFixed(2)} ${symbol}`
-            }
-          }
-        },
-        scales
-      })
+      this.chart.xAxis.data = this.data.map(i => this.convertDate(i.time))
+      this.chart.series[0].data = this.data.map(i => i.sum)
     },
     convertDate (num) {
       const date = new Date(num * 1000)
@@ -81,3 +87,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.echarts {
+  height: 190px;
+  width: 100%;
+}
+</style>

--- a/src/components/Dashboard/Charts/LineChartTable.vue
+++ b/src/components/Dashboard/Charts/LineChartTable.vue
@@ -1,10 +1,25 @@
+<template>
+  <div class="echarts">
+    <IEcharts
+      :option="chart"
+      :resizable="true"
+      @ready="onReady"
+    />
+  </div>
+</template>
+
 <script>
-import { Line } from 'vue-chartjs'
+import IEcharts from 'vue-echarts-v3/src/lite.js'
+import 'echarts/lib/chart/line'
+import 'echarts/lib/component/tooltip'
 import format from 'date-fns/format'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
 export default {
-  extends: Line,
+  name: 'line-chart-table',
+  components: {
+    IEcharts
+  },
   props: {
     data: {
       type: Array,
@@ -18,66 +33,57 @@ export default {
   mixins: [
     currencySymbol
   ],
+  data () {
+    return {
+      chart: {
+        grid: {
+          width: '104%',
+          height: '85%',
+          top: '10%',
+          // bottom: '0%',
+          left: '-2%'
+        },
+        tooltip: {
+          trigger: 'axis'
+        },
+        xAxis: {
+          show: true,
+          data: []
+        },
+        yAxis: {
+          show: false
+        },
+        series: [{
+          type: 'line',
+          symbol: 'none',
+          itemStyle: {
+            color: '#000000'
+          },
+          lineStyle: {
+            width: 1
+          },
+          areaStyle: {
+            color: '#fafafa'
+          },
+          data: []
+        }]
+      }
+    }
+  },
   watch: {
     data () {
-      this.updateChart()
+      this.onReady()
     }
   },
   methods: {
-    updateChart () {
-      const symbol = this.currencySymbol
-      let scales = {
-        xAxes: [{
-          gridLines: {
-            display: true,
-            drawTicks: true
-          },
-          ticks: {
-            display: true,
-            autoSkip: true,
-            maxTicksLimit: 10
-          }
-        }],
-        yAxes: [{
-          gridLines: {
-            display: true,
-            drawTicks: false,
-            drawBorder: false
-          },
-          ticks: {
-            display: false
-          }
-        }]
+    onReady (instance, ECharts) {
+      this.chart.tooltip.formatter = data => {
+        const value = data[0].value
+        const date = data[0].axisValue
+        return `${date}<br/>${value.toFixed(2)} ${this.currencySymbol}`
       }
-
-      this.renderChart({
-        labels: this.data.map(i => this.convertDate(i.time)),
-        datasets: [{
-          bezierCurve: false,
-          lineTension: 0,
-          backgroundColor: '#fafafa',
-          borderColor: '#000000',
-          borderWidth: 1,
-          data: this.data.map(i => i.close),
-          pointRadius: 0,
-          pointHitRadius: 10
-        }]
-      }, {
-        responsive: true,
-        maintainAspectRatio: false,
-        legend: {
-          display: false
-        },
-        tooltips: {
-          callbacks: {
-            label: function (tooltipItem, data) {
-              const value = data.datasets[0].data[tooltipItem.index] || 0
-              return `${value} ${symbol}`
-            }
-          }
-        },
-        scales
-      })
+      this.chart.xAxis.data = this.data.map(i => this.convertDate(i.time))
+      this.chart.series[0].data = this.data.map(i => i.close)
     },
     convertDate (num) {
       const filterFormat = {
@@ -94,3 +100,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.echarts {
+  height: 432px;
+  width: 100%;
+}
+</style>

--- a/src/components/Dashboard/Charts/LineChartTable.vue
+++ b/src/components/Dashboard/Charts/LineChartTable.vue
@@ -1,25 +1,19 @@
 <template>
   <div class="echarts">
-    <IEcharts
-      :option="chart"
-      :resizable="true"
+    <ECharts
+      :options="chart"
+      :auto-resize="true"
       @ready="onReady"
     />
   </div>
 </template>
 
 <script>
-import IEcharts from 'vue-echarts-v3/src/lite.js'
-import 'echarts/lib/chart/line'
-import 'echarts/lib/component/tooltip'
 import format from 'date-fns/format'
 import currencySymbol from '@/components/mixins/currencySymbol'
 
 export default {
   name: 'line-chart-table',
-  components: {
-    IEcharts
-  },
   props: {
     data: {
       type: Array,
@@ -38,9 +32,9 @@ export default {
       chart: {
         grid: {
           width: '104%',
-          height: '85%',
-          top: '10%',
-          // bottom: '0%',
+          height: '95%',
+          top: '0%',
+          bottom: '0%',
           left: '-2%'
         },
         tooltip: {

--- a/src/components/Dashboard/DashboardChart.vue
+++ b/src/components/Dashboard/DashboardChart.vue
@@ -81,6 +81,10 @@ export default {
   justify-content: flex-end;
 }
 
+.card-content_body {
+  height: 100%;
+}
+
 .chart_time-filter {
   float: left;
   opacity: 0.3;

--- a/src/components/Dashboard/DashboardDonutChart.vue
+++ b/src/components/Dashboard/DashboardDonutChart.vue
@@ -16,7 +16,7 @@
         </div>
       </el-col>
       <el-col class="donut-chart" :span="13">
-        <donut-chart :height="200" :data="portfolio"/>
+        <donut-chart :data="portfolio"/>
       </el-col>
     </el-row>
   </el-card>

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -23,7 +23,7 @@
             Market
           </div>
           <div>
-            <line-chart-portfolio chart-type="portfolio" :data="chartData"/>
+            <line-chart-portfolio :data="chartData"/>
           </div>
         </el-card>
     </el-col>

--- a/src/main.js
+++ b/src/main.js
@@ -53,6 +53,14 @@ import lang from 'element-ui/lib/locale/lang/en'
 import locale from 'element-ui/lib/locale'
 import 'cryptocoins-icons/webfont/cryptocoins.css'
 
+import ECharts from 'vue-echarts/components/ECharts'
+import 'echarts/lib/chart/line'
+import 'echarts/lib/chart/pie'
+import 'echarts/lib/component/tooltip'
+import 'echarts/lib/component/legendScroll'
+
+Vue.component('ECharts', ECharts)
+
 Vue.use(Dialog)
 Vue.use(Menu)
 Vue.use(MenuItem)

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const webpack = require('webpack')
 
 const rules = []
 
@@ -19,7 +18,6 @@ module.exports = {
     config.resolve.alias
       .set('@util', path.resolve(__dirname, 'src/util'))
       .set('@router', path.resolve(__dirname, 'src/router.js'))
-    config.plugin('IgnorePlugin').use(webpack.IgnorePlugin, [/^\.\/locale$/, /moment$/])
     config.plugin('html').tap(args => {
       args[0].chunksSortMode = 'none'
       return args

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,10 +2234,6 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-batch-processor@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
-
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -2639,26 +2635,6 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
-chart.js@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.7.2.tgz#3c9fde4dc5b95608211bdefeda7e5d33dffa5714"
-  dependencies:
-    chartjs-color "^2.1.0"
-    moment "^2.10.2"
-
-chartjs-color-string@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz#8d3752d8581d86687c35bfe2cb80ac5213ceb8c1"
-  dependencies:
-    color-name "^1.0.0"
-
-chartjs-color@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.2.0.tgz#84a2fb755787ed85c39dd6dd8c7b1d88429baeae"
-  dependencies:
-    chartjs-color-string "^0.5.0"
-    color-convert "^0.5.3"
-
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -2835,10 +2811,6 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
-
-color-convert@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
 
 color-convert@^1.9.0:
   version "1.9.1"
@@ -3652,7 +3624,7 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-echarts@^4.1.0:
+echarts@^4.0.4, echarts@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/echarts/-/echarts-4.1.0.tgz#d588c95f73c1a9928b9c73d5b769751c3185bcdc"
   dependencies:
@@ -3677,12 +3649,6 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.52:
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
-
-element-resize-detector@latest:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.14.tgz#af064a0a618a820ad570a95c5eec5b77be0128c1"
-  dependencies:
-    batch-processor "^1.0.0"
 
 element-ui@^2.4.4:
   version "2.4.4"
@@ -6091,7 +6057,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@latest, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -6482,10 +6448,6 @@ mocha@^5.2.0:
     minimatch "3.0.4"
     mkdirp "0.5.1"
     supports-color "5.4.0"
-
-moment@^2.10.2:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -8090,6 +8052,10 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resize-detector@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/resize-detector/-/resize-detector-0.1.7.tgz#48375f9d462afbcd9077d59580985020a84443f8"
+
 resize-observer-polyfill@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
@@ -9322,16 +9288,13 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue-chartjs@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-3.3.2.tgz#1bdbf859d0f5df6cac75d8510e51aee5865638ab"
-
-vue-echarts-v3@^1.0.19:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/vue-echarts-v3/-/vue-echarts-v3-1.0.19.tgz#6814e7e426aafed80edfa5df321db51c00789802"
+vue-echarts@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/vue-echarts/-/vue-echarts-3.0.9.tgz#bad7bdef12a1361a463f90ba57319f40afcd60ac"
   dependencies:
-    element-resize-detector latest
-    lodash latest
+    echarts "^4.0.4"
+    lodash "^4.17.10"
+    resize-detector "^0.1.7"
 
 vue-eslint-parser@^2.0.3:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,6 +2234,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+batch-processor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -3648,6 +3652,12 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+echarts@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-4.1.0.tgz#d588c95f73c1a9928b9c73d5b769751c3185bcdc"
+  dependencies:
+    zrender "4.0.4"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -3667,6 +3677,12 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.52:
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
+element-resize-detector@latest:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.14.tgz#af064a0a618a820ad570a95c5eec5b77be0128c1"
+  dependencies:
+    batch-processor "^1.0.0"
 
 element-ui@^2.4.4:
   version "2.4.4"
@@ -6075,7 +6091,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@latest, lodash@~4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -9310,6 +9326,13 @@ vue-chartjs@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-3.3.2.tgz#1bdbf859d0f5df6cac75d8510e51aee5865638ab"
 
+vue-echarts-v3@^1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/vue-echarts-v3/-/vue-echarts-v3-1.0.19.tgz#6814e7e426aafed80edfa5df321db51c00789802"
+  dependencies:
+    element-resize-detector latest
+    lodash latest
+
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
@@ -9756,3 +9779,7 @@ yorkie@^1.0.3:
     is-ci "^1.0.10"
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
+
+zrender@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-4.0.4.tgz#910e60d888f00c9599073f23758dd23345fe48fd"


### PR DESCRIPTION
# Description

Need to reduce size of charts. Current library for charts takes 540 KB also it require `moment.js` library, but it's that fully useless in our application.

### Bundle
#### Previous version
_Size_: 540 KB
![image](https://user-images.githubusercontent.com/16295803/43201709-ef89d0e2-9021-11e8-9cf6-a4f365ece957.png)

#### Current version
I changed `chart.js` to `echarts` and this doesn't help at all 😥. Bundle size changed from **540 KB** -> **1.6 MB**, but `echarts` documentation said that it can be minified to **~150 KB**
![image](https://user-images.githubusercontent.com/16295803/43249408-43bdcbe0-90c3-11e8-8bf4-e7acfdc48445.png)

Also I created issue, because I did as documentation says and don't get minified version. ~Currently i'm waiting for the response - [Echarts](https://goo.gl/4jkL4F)~

#### Works done
- [x] Changed `chart.js` to `echarts` 🤐

# How to check
1. `yarn` to install new packages.
2. `yarn build:more-memory --report` - to build production version with report.