### PR TITLE
D3-284 | Streaming of TX statuses

### DIFF
--- a/src/util/iroha-util.js
+++ b/src/util/iroha-util.js
@@ -376,7 +376,7 @@ function command (
         let statuses = []
 
         stream.on('data', function (response) {
-          clearInterval(timer)
+          clearTimeout(timer)
           statuses.push(response)
           timer = setTimeout(notaryError, timeoutLimit * 2)
         })


### PR DESCRIPTION
## Description
Since Iroha supports status streaming now, I have replaced status request with status streaming. It should work better than 5sec waiting.

## How to check
Try sending money. Please note that Iroha at our %secret-ip% isn't working now so please start local copy.

## Possible drawbacks
Since https://github.com/improbable-eng/grpc-web/pull/189 is not merged, if gRPC server hangs, in Google chrome uncaught exception happens and on(end) doesn't work. That's why I've using timeout there: to see if status requests aren't returning for some time. If grpc-web fix it, we can remove this code. (You can test this behaviour on our %secret-ip%).