### PR TITLE
[D3-280] market widget

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,7 @@ a:hover {
   overflow: scroll;
 }
 
+.el-popper,
 .el-tooltip__popper, .el-select-dropdown__item {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -63,7 +63,7 @@
 
               <div class="card-info" v-loading="cryptoInfo.isLoading">
                 <el-row style="margin-bottom: 20px">
-                  <el-col :span="12">
+                  <el-col :span="9">
                     <p
                       class="card-info-amount"
                       :title="`the current price of 1 ${wallet.asset} in ${settingsView.fiat}`"
@@ -78,7 +78,7 @@
                       {{ cryptoInfo.current.rur_change | formatNumberShort }}
                     </p>
                   </el-col>
-                  <el-col :span="12">
+                  <el-col :span="15">
                     <p
                       class="card-info-amount"
                       :title="`the current price of 1 ${wallet.asset} in ${settingsView.crypto}`"
@@ -96,7 +96,7 @@
                 </el-row>
 
                 <el-row>
-                  <el-col :span="8">
+                  <el-col :span="9">
                     <p class="card-info-title">Market Cap</p>
                     <p
                       class="card-info-amount--small"
@@ -112,7 +112,7 @@
                     </p>
                   </el-col>
                   <el-col :span="8">
-                    <p class="card-info-title">Volume</p>
+                    <p class="card-info-title">Volume ({{ selectedMarketPeriod }})</p>
                     <p
                       class="card-info-amount--small"
                       :title="`the amount ${wallet.asset} has been traded in ${selectedMarketPeriod} against ALL its trading pairs, in terms of ${settingsView.fiat}`"
@@ -126,7 +126,7 @@
                       {{ cryptoInfo.market.volume.crypto | formatNumberShort }} {{ wallet.asset }}
                     </p>
                   </el-col>
-                  <el-col :span="8">
+                  <el-col :span="7">
                     <p class="card-info-title">Circulating Supply</p>
                     <p
                       class="card-info-amount--small"

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -39,35 +39,65 @@
               <div slot="header" class="card-header">
                 <div>Market <el-tag type="info" size="mini">Today</el-tag></div>
               </div>
+
               <div class="card-info" v-loading="cryptoInfo.isLoading">
                 <el-row style="margin-bottom: 20px">
                   <el-col :span="12">
-                    <p class="card-info-amount">{{ cryptoInfo.current.rur | formatNumberLong }} {{ currencySymbol }}</p>
-                    <p :class="[cryptoInfo.current.rur_change > 0 ? 'uptrend' : 'downtrend']">
+                    <p
+                      class="card-info-amount"
+                      :title="`the current price in ${settingsView.fiat}`"
+                    >
+                      {{ cryptoInfo.current.rur | formatNumberLong }} {{ currencySymbol }}
+                    </p>
+
+                    <p
+                      :class="[cryptoInfo.current.rur_change > 0 ? 'uptrend' : 'downtrend']"
+                      :title="`the change (${settingsView.fiat}) for the last 24 hours`"
+                    >
                       {{ cryptoInfo.current.rur_change | formatNumberShort }}
                     </p>
                   </el-col>
                   <el-col :span="12">
-                    <p class="card-info-amount">{{ cryptoInfo.current.crypto | formatNumberLong }} {{ settingsView.crypto }}</p>
-                    <p :class="[cryptoInfo.current.crypto_change > 0 ? 'uptrend' : 'downtrend']">
+                    <p
+                      class="card-info-amount"
+                      :title="`the current price in ${settingsView.crypto}`"
+                    >
+                      {{ cryptoInfo.current.crypto | formatNumberLong }} {{ settingsView.crypto }}
+                    </p>
+
+                    <p
+                      :class="[cryptoInfo.current.crypto_change > 0 ? 'uptrend' : 'downtrend']"
+                      :title="`the change (%) for the last 24 hours`"
+                    >
                       {{ cryptoInfo.current.crypto_change | formatPercent }}
                     </p>
                   </el-col>
                 </el-row>
+
                 <el-row>
                   <el-col :span="8">
                     <p class="card-info-title">Market Cap</p>
-                    <p>{{ cryptoInfo.market.cap.rur | formatNumberShort }} {{ currencySymbol }}</p>
-                    <p>{{ cryptoInfo.market.cap.crypto | formatNumberShort }} {{ wallet.asset }}</p>
+                    <p :title="`the market cap in ${settingsView.fiat}`">
+                      {{ cryptoInfo.market.cap.rur | formatNumberShort }} {{ currencySymbol }}
+                    </p>
+                    <p :title="`the supply in ${wallet.asset}`">
+                      {{ cryptoInfo.market.cap.crypto | formatNumberShort }} {{ wallet.asset }}
+                    </p>
                   </el-col>
                   <el-col :span="8">
                     <p class="card-info-title">Volume (24h)</p>
-                    <p>{{ cryptoInfo.market.volume.rur | formatNumberShort }} {{ currencySymbol }}</p>
-                    <p>{{ cryptoInfo.market.volume.crypto | formatNumberShort }} {{ wallet.asset }}</p>
+                    <p :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${settingsView.fiat}`">
+                      {{ cryptoInfo.market.volume.rur | formatNumberShort }} {{ currencySymbol }}
+                    </p>
+                    <p :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${wallet.asset}`">
+                      {{ cryptoInfo.market.volume.crypto | formatNumberShort }} {{ wallet.asset }}
+                    </p>
                   </el-col>
                   <el-col :span="8">
                     <p class="card-info-title">Circulating Supply</p>
-                    <p> {{ cryptoInfo.market.supply | formatNumberShort }} {{ wallet.asset }}</p>
+                    <p :title="`the supply in ${wallet.asset}`">
+                      {{ cryptoInfo.market.supply | formatNumberShort }} {{ wallet.asset }}
+                    </p>
                   </el-col>
                 </el-row>
               </div>

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -68,14 +68,14 @@
                       class="card-info-amount"
                       :title="`the current price of 1 ${wallet.asset} in ${settingsView.fiat}`"
                     >
-                      {{ cryptoInfo.current.rur | formatNumberLong }} {{ currencySymbol }}
+                      {{ cryptoInfo.current.fiat | formatNumberLong }} {{ currencySymbol }}
                     </p>
 
                     <p
-                      :class="[cryptoInfo.current.rur_change > 0 ? 'uptrend' : 'downtrend']"
+                      :class="[cryptoInfo.current.fiat_change > 0 ? 'uptrend' : 'downtrend']"
                       :title="`the change (${settingsView.fiat}) from ${selectedMarketPeriod} ago`"
                     >
-                      {{ cryptoInfo.current.rur_change | formatNumberShort }}
+                      {{ cryptoInfo.current.fiat_change | formatNumberShort }}
                     </p>
                   </el-col>
                   <el-col :span="15">
@@ -102,7 +102,7 @@
                       class="card-info-amount--small"
                       :title="`the market cap in ${settingsView.fiat}`"
                     >
-                      {{ cryptoInfo.market.cap.rur | formatNumberShort }} {{ currencySymbol }}
+                      {{ cryptoInfo.market.cap.fiat | formatNumberShort }} {{ currencySymbol }}
                     </p>
                     <p
                       class="card-info-amount--small"
@@ -117,7 +117,7 @@
                       class="card-info-amount--small"
                       :title="`the amount ${wallet.asset} has been traded in ${selectedMarketPeriod} against ALL its trading pairs, in terms of ${settingsView.fiat}`"
                     >
-                      {{ cryptoInfo.market.volume.rur | formatNumberShort }} {{ currencySymbol }}
+                      {{ cryptoInfo.market.volume.fiat | formatNumberShort }} {{ currencySymbol }}
                     </p>
                     <p
                       class="card-info-amount--small"

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -112,16 +112,16 @@
                     </p>
                   </el-col>
                   <el-col :span="8">
-                    <p class="card-info-title">Volume (24h)</p>
+                    <p class="card-info-title">Volume</p>
                     <p
                       class="card-info-amount--small"
-                      :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${settingsView.fiat}`"
+                      :title="`the amount ${wallet.asset} has been traded in ${selectedMarketPeriod} against ALL its trading pairs, in terms of ${settingsView.fiat}`"
                     >
                       {{ cryptoInfo.market.volume.rur | formatNumberShort }} {{ currencySymbol }}
                     </p>
                     <p
                       class="card-info-amount--small"
-                      :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${wallet.asset}`"
+                      :title="`the amount ${wallet.asset} has been traded in ${selectedMarketPeriod} against ALL its trading pairs, in terms of ${wallet.asset}`"
                     >
                       {{ cryptoInfo.market.volume.crypto | formatNumberShort }} {{ wallet.asset }}
                     </p>
@@ -130,7 +130,7 @@
                     <p class="card-info-title">Circulating Supply</p>
                     <p
                       class="card-info-amount--small"
-                      :title="`the supply in ${wallet.asset}`"
+                      :title="`the total supply in ${wallet.asset}`"
                     >
                       {{ cryptoInfo.market.supply | formatNumberShort }} {{ wallet.asset }}
                     </p>

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -106,7 +106,7 @@
                     </p>
                     <p
                       class="card-info-amount--small"
-                      :title="`the supply in ${wallet.asset}`"
+                      :title="`the market cap in ${wallet.asset}`"
                     >
                       {{ cryptoInfo.market.cap.crypto | formatNumberShort }} {{ wallet.asset }}
                     </p>

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -98,25 +98,40 @@
                 <el-row>
                   <el-col :span="8">
                     <p class="card-info-title">Market Cap</p>
-                    <p :title="`the market cap in ${settingsView.fiat}`">
+                    <p
+                      class="card-info-amount--small"
+                      :title="`the market cap in ${settingsView.fiat}`"
+                    >
                       {{ cryptoInfo.market.cap.rur | formatNumberShort }} {{ currencySymbol }}
                     </p>
-                    <p :title="`the supply in ${wallet.asset}`">
+                    <p
+                      class="card-info-amount--small"
+                      :title="`the supply in ${wallet.asset}`"
+                    >
                       {{ cryptoInfo.market.cap.crypto | formatNumberShort }} {{ wallet.asset }}
                     </p>
                   </el-col>
                   <el-col :span="8">
                     <p class="card-info-title">Volume (24h)</p>
-                    <p :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${settingsView.fiat}`">
+                    <p
+                      class="card-info-amount--small"
+                      :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${settingsView.fiat}`"
+                    >
                       {{ cryptoInfo.market.volume.rur | formatNumberShort }} {{ currencySymbol }}
                     </p>
-                    <p :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${wallet.asset}`">
+                    <p
+                      class="card-info-amount--small"
+                      :title="`the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${wallet.asset}`"
+                    >
                       {{ cryptoInfo.market.volume.crypto | formatNumberShort }} {{ wallet.asset }}
                     </p>
                   </el-col>
                   <el-col :span="8">
                     <p class="card-info-title">Circulating Supply</p>
-                    <p :title="`the supply in ${wallet.asset}`">
+                    <p
+                      class="card-info-amount--small"
+                      :title="`the supply in ${wallet.asset}`"
+                    >
                       {{ cryptoInfo.market.supply | formatNumberShort }} {{ wallet.asset }}
                     </p>
                   </el-col>
@@ -614,6 +629,10 @@ export default {
   font-size: 16px;
   font-weight: bold;
   margin-bottom: 4px;
+}
+
+.card-info-amount--small {
+  word-break: break-all;
 }
 
 .icon {

--- a/src/main.js
+++ b/src/main.js
@@ -48,7 +48,10 @@ import {
   Main,
   Loading,
   Message,
-  MessageBox
+  MessageBox,
+  Dropdown,
+  DropdownMenu,
+  DropdownItem
 } from 'element-ui'
 import lang from 'element-ui/lib/locale/lang/en'
 import locale from 'element-ui/lib/locale'
@@ -85,6 +88,9 @@ Vue.use(Container)
 Vue.use(Header)
 Vue.use(Aside)
 Vue.use(Main)
+Vue.use(Dropdown)
+Vue.use(DropdownMenu)
+Vue.use(DropdownItem)
 Vue.use(Loading.directive)
 Vue.prototype.$alert = MessageBox.alert
 Vue.prototype.$message = Message

--- a/src/store/Wallet.js
+++ b/src/store/Wallet.js
@@ -21,18 +21,18 @@ function initialState () {
   return {
     cryptoInfo: {
       current: {
-        rur: 0,
-        rur_change: 0,
+        fiat: 0,
+        fiat_change: 0,
         crypto: 0,
         crypto_change: 0
       },
       market: {
         cap: {
-          rur: 0,
+          fiat: 0,
           crypto: 0
         },
         volume: {
-          rur: 0,
+          fiat: 0,
           crypto: 0
         },
         supply: 0
@@ -84,14 +84,14 @@ const mutations = {
   ) {
     // process priceData
     const RAW = Object.values(priceData.RAW)[0]
-    const compareToRUB = RAW[currencies.fiat]
+    const compareToFiat = RAW[currencies.fiat]
     const compareToCrypto = RAW[currencies.crypto]
 
-    const priceFiat = compareToRUB.PRICE
+    const priceFiat = compareToFiat.PRICE
     const priceCrypto = compareToCrypto.PRICE
-    const marketcapFiat = compareToRUB.MKTCAP
-    const marketcapCrypto = compareToRUB.SUPPLY
-    const circulatingSupply = compareToRUB.SUPPLY
+    const marketcapFiat = compareToFiat.MKTCAP
+    const marketcapCrypto = compareToFiat.SUPPLY
+    const circulatingSupply = compareToFiat.SUPPLY
 
     // process historicalData
     const getChangeInfo = ({ Data }) => {
@@ -113,18 +113,18 @@ const mutations = {
 
     Vue.set(state, 'cryptoInfo', {
       current: {
-        rur: priceFiat,
-        rur_change: changeFiat,
+        fiat: priceFiat,
+        fiat_change: changeFiat,
         crypto: priceCrypto,
         crypto_change: changePctCrypto
       },
       market: {
         cap: {
-          rur: marketcapFiat,
+          fiat: marketcapFiat,
           crypto: marketcapCrypto
         },
         volume: {
-          rur: volumeFiat,
+          fiat: volumeFiat,
           crypto: volumeCrypto
         },
         supply: circulatingSupply

--- a/src/util/cryptoApi-axios-util.js
+++ b/src/util/cryptoApi-axios-util.js
@@ -28,8 +28,9 @@ const loadHistoryByLabels = axios => (currencies, settings, options = {}) => {
     }))
 }
 
-const loadPriceByFilter = axios => ({ crypto, filter }, settings) => {
-  const currentFiat = settings.fiat
+const loadPriceByFilter = axios => ({ crypto, filter, to }, settings) => {
+  const fsym = crypto
+  const tsym = to || settings.fiat
   const dateFilter = {
     'ALL': {
       url: 'histoday',
@@ -60,8 +61,8 @@ const loadPriceByFilter = axios => ({ crypto, filter }, settings) => {
   return axios
     .get(`data/${search.url}`, {
       params: {
-        fsym: crypto,
-        tsym: currentFiat,
+        fsym,
+        tsym,
         limit: search.time
       }
     })

--- a/src/util/cryptoApi-axios-util.js
+++ b/src/util/cryptoApi-axios-util.js
@@ -70,6 +70,45 @@ const loadPriceByFilter = axios => ({ crypto, filter, to }, settings) => {
     .catch(error => ({ error }))
 }
 
+const loadVolumeByFilter = axios => ({ crypto, filter }) => {
+  const dateFilter = {
+    'ALL': {
+      url: 'histoday',
+      time: 730
+    },
+    '1Y': {
+      url: 'histoday',
+      time: 365
+    },
+    '1M': {
+      url: 'histoday',
+      time: 30
+    },
+    '1W': {
+      url: 'histoday',
+      time: 7
+    },
+    '1D': {
+      url: 'histohour',
+      time: 24
+    },
+    '1H': {
+      url: 'histohour',
+      time: 1
+    }
+  }
+  const search = dateFilter[filter]
+  return axios
+    .get(`data/exchange/${search.url}`, {
+      params: {
+        tsym: crypto,
+        limit: search.time
+      }
+    })
+    .then(({ data }) => data)
+    .catch(error => ({ error }))
+}
+
 const loadFullData = axios => (asset, currencies) => {
   const currentFiat = currencies.fiat
   const currentCrypto = currencies.crypto
@@ -99,6 +138,7 @@ const loadPriceForAssets = axios => (assets) => {
 export default {
   loadHistoryByLabels: loadHistoryByLabels(axiosAPI),
   loadPriceByFilter: loadPriceByFilter(axiosAPI),
+  loadVolumeByFilter: loadVolumeByFilter(axiosAPI),
   loadFullData: loadFullData(axiosAPI),
   loadPriceForAssets: loadPriceForAssets(axiosAPI)
 }

--- a/tests/unit/store/Wallets.spec.js
+++ b/tests/unit/store/Wallets.spec.js
@@ -25,18 +25,18 @@ describe('Wallet store', () => {
       const state = {
         cryptoInfo: {
           current: {
-            rur: randomAmountRng(),
-            rur_change: randomAmountRng(),
+            fiat: randomAmountRng(),
+            fiat_change: randomAmountRng(),
             crypto: randomAmountRng(),
             crypto_change: randomAmountRng()
           },
           market: {
             cap: {
-              rur: randomAmountRng(),
+              fiat: randomAmountRng(),
               crypto: randomAmountRng()
             },
             volume: {
-              rur: randomAmountRng(),
+              fiat: randomAmountRng(),
               crypto: randomAmountRng()
             },
             supply: randomAmountRng()
@@ -48,18 +48,18 @@ describe('Wallet store', () => {
       const expectedState = {
         cryptoInfo: {
           current: {
-            rur: 0,
-            rur_change: 0,
+            fiat: 0,
+            fiat_change: 0,
             crypto: 0,
             crypto_change: 0
           },
           market: {
             cap: {
-              rur: 0,
+              fiat: 0,
               crypto: 0
             },
             volume: {
-              rur: 0,
+              fiat: 0,
               crypto: 0
             },
             supply: 0
@@ -131,18 +131,18 @@ describe('Wallet store', () => {
       const expectedState = {
         cryptoInfo: {
           current: {
-            rur: price,
-            rur_change: 0,
+            fiat: price,
+            fiat_change: 0,
             crypto: price,
             crypto_change: 0
           },
           market: {
             cap: {
-              rur: number,
+              fiat: number,
               crypto: number
             },
             volume: {
-              rur: price * (number * 2),
+              fiat: price * (number * 2),
               crypto: number * 2
             },
             supply: number
@@ -203,18 +203,18 @@ describe('Wallet store', () => {
         const state = {
           cryptoInfo: {
             current: {
-              rur: randomAmountRng(),
-              rur_change: randomAmountRng(),
+              fiat: randomAmountRng(),
+              fiat_change: randomAmountRng(),
               crypto: randomAmountRng(),
               crypto_change: randomAmountRng()
             },
             market: {
               cap: {
-                rur: randomAmountRng(),
+                fiat: randomAmountRng(),
                 crypto: randomAmountRng()
               },
               volume: {
-                rur: randomAmountRng(),
+                fiat: randomAmountRng(),
                 crypto: randomAmountRng()
               },
               supply: randomAmountRng()

--- a/tests/unit/store/Wallets.spec.js
+++ b/tests/unit/store/Wallets.spec.js
@@ -91,7 +91,19 @@ describe('Wallet store', () => {
         fiat,
         crypto: asset
       }
-      const data = {
+      const historicalDataFiat = {
+        Data: [
+          { close: number },
+          { close: number }
+        ]
+      }
+      const historicalDataCrypto = {
+        Data: [
+          { close: number },
+          { close: number }
+        ]
+      }
+      const priceData = {
         RAW: {
           test: {
             [fiat]: {
@@ -113,9 +125,9 @@ describe('Wallet store', () => {
         cryptoInfo: {
           current: {
             rur: number,
-            rur_change: number,
+            rur_change: 0,
             crypto: number,
-            crypto_change: number
+            crypto_change: 0
           },
           market: {
             cap: {
@@ -132,7 +144,9 @@ describe('Wallet store', () => {
         }
       }
       mutations[types.GET_CRYPTO_FULL_DATA_SUCCESS](state, {
-        data,
+        historicalDataFiat,
+        historicalDataCrypto,
+        priceData,
         currencies
       })
       expect(state).to.be.deep.equal(expectedState)
@@ -155,6 +169,7 @@ describe('Wallet store', () => {
       it('should call mutations in correct order', async () => {
         const assets = ['BTC', 'ETH']
         const fiats = ['USD', 'EUR']
+        const filter = '1D'
         const asset = randomArrayElement(assets)
         const fiat = randomArrayElement(fiats)
         const getters = {
@@ -164,7 +179,7 @@ describe('Wallet store', () => {
           }
         }
         const commit = sinon.spy()
-        await actions.getCryptoFullData({ commit, getters }, { asset })
+        await actions.getCryptoFullData({ commit, getters }, { filter, asset })
         const response = commit.secondCall.args[1]
         expect(commit.args).to.deep.equal([
           [types.GET_CRYPTO_FULL_DATA_REQUEST],

--- a/tests/unit/store/Wallets.spec.js
+++ b/tests/unit/store/Wallets.spec.js
@@ -83,6 +83,7 @@ describe('Wallet store', () => {
     it('GET_CRYPTO_FULL_DATA_SUCCESS should set cryptoInfo data', () => {
       const state = { cryptoInfo: {} }
       const number = randomAmountRng()
+      const price = randomAmountRng()
       const assets = ['BTC', 'ETH']
       const fiats = ['USD', 'EUR']
       const asset = randomArrayElement(assets)
@@ -103,11 +104,17 @@ describe('Wallet store', () => {
           { close: number }
         ]
       }
+      const volumeData = {
+        Data: [
+          { volume: number },
+          { volume: number }
+        ]
+      }
       const priceData = {
         RAW: {
           test: {
             [fiat]: {
-              PRICE: number,
+              PRICE: price,
               CHANGEDAY: number,
               MKTCAP: number,
               SUPPLY: number,
@@ -115,7 +122,7 @@ describe('Wallet store', () => {
               TOTALVOLUME24H: number
             },
             [asset]: {
-              PRICE: number,
+              PRICE: price,
               CHANGEPCTDAY: number
             }
           }
@@ -124,9 +131,9 @@ describe('Wallet store', () => {
       const expectedState = {
         cryptoInfo: {
           current: {
-            rur: number,
+            rur: price,
             rur_change: 0,
-            crypto: number,
+            crypto: price,
             crypto_change: 0
           },
           market: {
@@ -135,8 +142,8 @@ describe('Wallet store', () => {
               crypto: number
             },
             volume: {
-              rur: number,
-              crypto: number
+              rur: price * (number * 2),
+              crypto: number * 2
             },
             supply: number
           },
@@ -146,6 +153,7 @@ describe('Wallet store', () => {
       mutations[types.GET_CRYPTO_FULL_DATA_SUCCESS](state, {
         historicalDataFiat,
         historicalDataCrypto,
+        volumeData,
         priceData,
         currencies
       })


### PR DESCRIPTION
# Description

Previously, a market widget in a wallet page used only `pricemultifull` API but it returned only today's or 24h values, therefore we couldn't see market data with other time ranges. In order to support other time ranges, I changed it to use also `histo{day,hour,minute}` and `exchange/histo{day,hour}` APIs and made it calculate the changes (B, D) and the total volumes (G, H) with these historical data.

![back-office](https://user-images.githubusercontent.com/1365915/44899970-50349100-ad3e-11e8-8bf8-34a4b34c893c.png)

* [x] B
    * the change (${settingsView.fiat}) from today's open
    * ⬇️ 
    * the change (${settingsView.fiat}) from **${selectedMarketPeriod} ago**
* [x] D
    * the change (%) from today's open
    * ⬇️ 
    * the change (%) from **${selectedMarketPeriod} ago**
* [x] G
    * the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${settingsView.fiat}
    * ⬇️ 
    * the amount ${wallet.asset} has been traded in **${selectedMarketPeriod}** against ALL its trading pairs, in terms of ${settingsView.fiat}
* [x] H
    * the amount ${wallet.asset} has been traded in 24 hours against ALL its trading pairs, in terms of ${wallet.asset}
    * ⬇️ 
    * the amount ${wallet.asset} has been traded in **${selectedMarketPeriod}** against ALL its trading pairs, in terms of ${wallet.asset}

# Known issues
* Historical volume API can return abnormal huge values like this, so goes the accumulated value. 🐷 I believe it is a CryptoCompare's issue because there are no such pulses in other services like [CoinMarketCap](https://coinmarketcap.com/) or [CryptoCurrencyChart](https://www.cryptocurrencychart.com/).
    * Opened an issue to our backlog https://soramitsu.atlassian.net/browse/D3-374

![back-office](https://user-images.githubusercontent.com/1365915/44902416-eb306980-ad44-11e8-9620-1036d4120efa.png)

* A market cap differs from that of [CoinMarketCap](https://coinmarketcap.com/) for the following reason:
    * CoinMarketCap calculates a market cap with `CirculatingSupply * Price` (CirculatingSupply is, according to their [FAQ](https://coinmarketcap.com/faq/), the best approximation of the number of coins that are circulating in the market)
    * Whereas CryptoCompare calculates a market cap with `TotalSupply * Price`

# How to check
1. `yarn serve` to open the app
2. Go to a wallet page and check a market widget. Click the tag and you can select the range.
![screen shot 2018-08-31 at 16 50 27](https://user-images.githubusercontent.com/1365915/44899949-3f841b00-ad3e-11e8-8fdf-272d9cacdb12.png)
You can see the description on hover.
![untitled](https://user-images.githubusercontent.com/1365915/45342363-ac1dd600-b5d8-11e8-9ce5-6cd511787995.png)
