### PR TITLE
fix: updated iroha-helpers v0.1.1

### DIFF
--- a/scripts/setup-accounts-and-assets.js
+++ b/scripts/setup-accounts-and-assets.js
@@ -20,7 +20,7 @@ const testPubKey = derivePublicKey(Buffer.from(testPrivKeyHex, 'hex'))
 const alicePrivKeyHex = fs.readFileSync(path.join(__dirname, `${aliceAccFull}.priv`)).toString().trim()
 const alicePubKey = derivePublicKey(Buffer.from(alicePrivKeyHex, 'hex'))
 
-const nodeIp = process.env.NODE_IP || 'http://127.0.0.1:8080'
+const nodeIp = process.env.NODE_IP || 'http://127.0.0.1:8081'
 const DUMMY_FILE_PATH = path.join(__dirname, '../src/mocks/wallets.json')
 const accounts = [testAccFull, aliceAccFull]
 const wallets = require(DUMMY_FILE_PATH).wallets
@@ -89,7 +89,7 @@ function setupAccountTransactions (accountId, accountPrivKeyHex) {
           const message = _.sample(['hello', 'hi', '', 'PART_OF_DUMMY_SETTLEMENT'])
           const amount = String(Math.random()).substr(0, precision + 2)
 
-          const p = irohaUtil.transferAsset(testPrivKeyHex, from, to, `${w.name.toLowerCase()}#${irohaDomain}`, message, amount).catch(() => {})
+          const p = irohaUtil.transferAsset(accountPrivKeyHex, from, to, `${w.name.toLowerCase()}#${irohaDomain}`, message, amount).catch(() => {})
 
           txs.push(p)
         })

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -236,7 +236,7 @@
           <el-input
             type="textarea"
             :rows="2"
-            :model="transferForm.description"
+            v-model="transferForm.description"
             placeholder="Details"
             resize="none"
           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5285,9 +5285,9 @@ ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
 
-iroha-helpers@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/iroha-helpers/-/iroha-helpers-0.0.4.tgz#80ff15676c07d6b967571061c9e136f10cae4a9b"
+iroha-helpers@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/iroha-helpers/-/iroha-helpers-0.1.1.tgz#9db869d0baf09f3d9dd611fd6c5ba82d804ea928"
   dependencies:
     buffer "^5.2.0"
     ed25519.js "^1.2.0"


### PR DESCRIPTION
# Description
Added `yarn.lock` to #45 and added several fixes.

#### Works done
- [x] Fixed setup script, now transactions signed correctly with private key.
- [x] Fixed transferForm. Now description sends correctly.
- [x] Updated yarn lock

# How to check
- yarn to install new packages.
- yarn serve to run dev server.