### PR TITLE
D3-338 | Update grpc web

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ed25519.js": "^1.3.0",
     "element-ui": "^2.4.6",
     "file-saver": "^1.3.8",
-    "grpc-web-client": "^0.6.2",
+    "grpc-web-client": "^0.6.3",
     "iroha-helpers": "^0.1.1",
     "json2csv": "^4.2.1",
     "lodash": "^4.17.10",

--- a/src/util/iroha-util.js
+++ b/src/util/iroha-util.js
@@ -360,29 +360,19 @@ function command (
       debug('opening transaction status stream...')
 
       return new Promise((resolve, reject) => {
-        const request = new TxStatusRequest()
+        let statuses = []
 
+        const request = new TxStatusRequest()
         request.setTxHash(txHash)
 
         let stream = txClient.statusStream(request)
-
-        // TODO: fix this if (when) https://github.com/improbable-eng/grpc-web/pull/189 is merged
-        const notaryError = () => {
-          reject(new Error('Problem with notary. Please try again later.'))
-          stream.cancel()
-        }
-        let timer = setTimeout(notaryError, timeoutLimit * 4)
-
-        let statuses = []
-
         stream.on('data', function (response) {
-          clearTimeout(timer)
           statuses.push(response)
-          timer = setTimeout(notaryError, timeoutLimit * 4)
         })
 
         stream.on('end', function (end) {
-          clearTimeout(timer)
+          // Throw error if Iroha closed connection without sending status responses
+          if (statuses.length === 0) return reject(new Error('Problems with notary service. Please try again later.'))
 
           const last = statuses[statuses.length - 1].getTxStatus()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4871,6 +4871,12 @@ grpc-web-client@^0.6.2:
   dependencies:
     browser-headers "^0.4.0"
 
+grpc-web-client@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/grpc-web-client/-/grpc-web-client-0.6.3.tgz#b3f527db570978cba51a30004d922bad9138962d"
+  dependencies:
+    browser-headers "^0.4.0"
+
 gzip-size@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.1.0.tgz#8ae096257eabe7d69c45be2b67c448124ffb517c"


### PR DESCRIPTION
## Description
Since https://github.com/improbable-eng/grpc-web/pull/189 was merged and https://www.npmjs.com/package/grpc-web-client/v/0.6.3 was released, we need to fix TODO in `iroha-util` and remove "dirty hack": setTimeout. Now (if notary hangs) we can work properly with onEnd event.

## How to check
Try sending transaction at our %secret-notary-ip% – it is hanged now :)