### PR TITLE
Allow sending transactions with only one key

### DIFF
--- a/scripts/setup-accounts-and-assets.js
+++ b/scripts/setup-accounts-and-assets.js
@@ -40,7 +40,8 @@ irohaUtil.login(testAccFull, testPrivKeyHex, nodeIp)
   .then(() => setupAccountTransactions(testAccFull, testPrivKeyHex))
   .then(() => setupAccountTransactions(aliceAccFull, alicePrivKeyHex))
   // Let's use alice's private key as 2nd key for now
-  .then(() => tryToSetQuorum(testPrivKeyHex, testAccFull, alicePubKey, 2))
+  .then(() => tryToAddSignatory(testPrivKeyHex, testAccFull, alicePubKey))
+  .then(() => tryToSetQuorum(testPrivKeyHex, testAccFull, 2))
   .then(() => console.log('done!'))
   .catch(err => console.error(err))
 
@@ -146,8 +147,8 @@ function tryToCreateAsset (assetName, domainId, precision) {
   })
 }
 
-function tryToSetQuorum (accountPrivKeyHex, accountId, publicKey, quorum) {
-  console.log(`trying to add signature and set quorum to account: ${accountId}`)
+function tryToAddSignatory (accountPrivKeyHex, accountId, publicKey) {
+  console.log(`trying to add signature to account: ${accountId}`)
 
   return new Promise((resolve, reject) => {
     irohaUtil.login(accountId, accountPrivKeyHex, nodeIp)
@@ -155,6 +156,19 @@ function tryToSetQuorum (accountPrivKeyHex, accountId, publicKey, quorum) {
         console.log(`add signature to account: ${accountId} (signature:${publicKey})`)
         irohaUtil.addSignatory([accountPrivKeyHex], accountId, publicKey)
       })
+      .then(() => {
+        console.log(`siganture is added`)
+        irohaUtil.logout()
+        resolve()
+      })
+      .catch((err) => reject(err))
+  })
+}
+function tryToSetQuorum (accountPrivKeyHex, accountId, quorum) {
+  console.log(`trying to add signature and set quorum to account: ${accountId}`)
+
+  return new Promise((resolve, reject) => {
+    irohaUtil.login(accountId, accountPrivKeyHex, nodeIp)
       .then(() => {
         console.log(`set account quorum to account: ${accountId} (quorum:${quorum})`)
         irohaUtil.setAccountQuorum([accountPrivKeyHex], accountId, quorum)

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -156,6 +156,7 @@
               <el-input
                 placeholder="Your private key"
                 v-model="key.hex"
+                :class="{ 'is-empty': !key.hex }"
               />
             </el-col>
 
@@ -382,7 +383,9 @@ export default {
     updateNumberOfValidKeys () {
       if (!this.$refs.approvalForm) return
 
-      this.approvalForm.numberOfValidKeys = this.$refs.approvalForm.fields.filter(x => x.validateState === 'success').length
+      this.approvalForm.numberOfValidKeys = this.$refs.approvalForm.fields.filter(x => {
+        return x.validateState === 'success' && !!x.fieldValue
+      }).length
     }
   }
 }
@@ -438,5 +441,10 @@ export default {
   border: solid 1px #cccccc;
   display: flex;
   justify-content: center;
+}
+
+/* in order not to make a border green when a private key is empty */
+.el-form-item.is-success .el-input.is-empty .el-input__inner {
+  border-color: #dcdfe6;
 }
 </style>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -317,7 +317,7 @@ export default {
     submitApprovalDialog () {
       this.$refs.approvalForm.validate(valid => {
         if (!valid) return
-        this.closeApprovalDialog(this.approvalForm.privateKeys.map(x => x.hex))
+        this.closeApprovalDialog(this.approvalForm.privateKeys.map(x => x.hex).filter(x => !!x))
       })
     },
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -76,7 +76,7 @@ export default {
   mixins: [
     inputValidation({
       username: 'nameDomain',
-      privateKey: 'privateKey',
+      privateKey: 'privateKeyRequired',
       nodeIp: 'nodeIp'
     })
   ],

--- a/src/components/mixins/inputValidation.js
+++ b/src/components/mixins/inputValidation.js
@@ -11,7 +11,6 @@ const set = {
     { pattern: /^[a-z_0-9]{1,32}@[a-z_0-9]{1,9}$/, message: 'Username should match [a-Z_0-9]{1,32}@[a-Z_0-9]{1,9}', trigger: 'change' }
   ],
   privateKey: [
-    { required: true, message: 'Please input private key', trigger: 'change' },
     { pattern: /^[A-Za-z0-9]{64}$/, message: 'Private key should match [A-Za-z0-9]{64}', trigger: 'change' }
   ],
   nodeIp: [
@@ -26,6 +25,11 @@ const set = {
     { pattern: /^(?![0.]+$)\d+(\.\d+)?$/, message: 'Invalid amount', trigger: 'change' }
   ]
 }
+
+set['privateKeyRequired'] = [
+  { required: true, message: 'Please input private key', trigger: 'change' },
+  ...set['privateKey']
+]
 
 const getPrecision = (v) => (v.split('.')[1] || []).length
 


### PR DESCRIPTION
# Description
It allows you to send transactions with only one key.

![back-office](https://user-images.githubusercontent.com/1365915/45862549-2e628300-bdad-11e8-96fc-63dd390ff3e9.png)

# How to check
1. `yarn serve` and open the app with test@notary whose quorum > 1.
2. Try to send some transactions with only one key.