### PR TITLE
D3-334, D3-234 | Pending transaction getting & signing

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -139,7 +139,8 @@
           <el-row type="flex" justify="center">
             <p>
               Please enter your private key<span v-if="accountQuorum > 1">s</span>.
-              <br>
+            </p>
+            <p v-if="accountQuorum > 1">
               (You need to enter at least 1 key)
             </p>
             <p v-if="approvalForm.numberOfSignatures">This transaction already has {{approvalForm.numberOfSignatures}} signature<span v-if="approvalForm.numberOfSignatures > 1">s</span></p>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -142,6 +142,7 @@
               <br>
               (You need to enter at least 1 key)
             </p>
+            <p v-if="approvalForm.numberOfSignatures">This transaction already has {{approvalForm.numberOfSignatures}} signature<span v-if="approvalForm.numberOfSignatures > 1">s</span></p>
           </el-row>
         </el-form-item>
 
@@ -176,7 +177,7 @@
         <el-form-item v-if="accountQuorum > 1">
           <el-row type="flex" justify="center">
             <div class="item__private-keys">
-              {{ approvalForm.numberOfValidKeys }}/{{ accountQuorum }}
+              {{ approvalForm.numberOfValidKeys + approvalForm.numberOfSignatures }}/{{ accountQuorum }}
             </div>
           </el-row>
         </el-form-item>
@@ -221,7 +222,8 @@ export default {
       },
       approvalForm: {
         privateKeys: [],
-        numberOfValidKeys: 0
+        numberOfValidKeys: 0,
+        numberOfSignatures: 0
       },
       isExchangeSending: false
     }

--- a/src/components/Transactions/TransactionPage.vue
+++ b/src/components/Transactions/TransactionPage.vue
@@ -53,7 +53,7 @@
                 <template slot-scope="scope">
                   <div>
                     <el-button
-                      @click="onSubmitTransferForm(row.scope.id)"
+                      @click="onSubmitTransferForm(scope.row.id)"
                       size="medium"
                       type="primary"
                       plain
@@ -84,6 +84,7 @@ export default {
   ],
   data () {
     return {
+      isSending: false
     }
   },
   computed: {
@@ -115,9 +116,7 @@ export default {
                 message: 'Transaction succesfuly finalised and sent!',
                 type: 'success'
               })
-              this.fetchWallet()
-              this.resetTransferForm()
-              this.transferFormVisible = false
+              this.$store.dispatch('getPendingTransactions')
             })
             .catch(err => {
               console.error(err)

--- a/src/components/Transactions/TransactionPage.vue
+++ b/src/components/Transactions/TransactionPage.vue
@@ -53,7 +53,7 @@
                 <template slot-scope="scope">
                   <div>
                     <el-button
-                      @click="onSubmitTransferForm(scope.row.id)"
+                      @click="onSignPendingTransaction(scope.row.id)"
                       size="medium"
                       type="primary"
                       plain
@@ -101,7 +101,7 @@ export default {
     ...mapActions([
       'openApprovalDialog'
     ]),
-    onSubmitTransferForm (txStoreId) {
+    onSignPendingTransaction (txStoreId) {
       this.openApprovalDialog()
         .then(privateKeys => {
           if (!privateKeys) return

--- a/src/components/Transactions/TransactionPage.vue
+++ b/src/components/Transactions/TransactionPage.vue
@@ -107,11 +107,4 @@ export default {
 .transactions__table-row {
   height: 72px;
 }
-.row__amount {
-  display: flex;
-  flex-direction: column;
-}
-.row__amount span {
-  font-weight: 600;
-}
 </style>

--- a/src/components/Transactions/TransactionPage.vue
+++ b/src/components/Transactions/TransactionPage.vue
@@ -2,41 +2,54 @@
   <el-container>
     <el-main>
       <el-row>
-        <el-col :xs="24" :md="{ span: 18, offset: 3}" :lg="{ span: 16, offset: 4 }" :xl="{ span: 14, offset: 5 }">
+        <el-col :xs="24" :lg="{ span: 18, offset: 3 }" :xl="{ span: 16, offset: 4 }">
           <el-card>
             <div slot="header" style="display: flex; justify-content: space-between; align-items: center;">
-              <span>Waiting transactions</span>
+              <span>Waiting transactions to be signed</span>
             </div>
             <el-table
               row-class-name="transactions__table-row"
-              :data="mockData">
-              <el-table-column type="expand"></el-table-column>
+              :data="allPendingTransactions">
+              <el-table-column type="expand">
+                <template slot-scope="scope">
+                  <p>
+                    {{ scope.row.from }} transfered  {{ scope.row.amount + ' ' + wallets.find(w => w.assetId = scope.row.assetId).asset}} to {{ scope.row.to }}
+                  </p>
+                  <div>
+                    <p>Was <el-tag>created</el-tag> at {{ formatDateLong(scope.row.date) }}</p>
+                    <p>Message: {{ scope.row.message }}</p>
+                  </div>
+                </template>
+              </el-table-column>
               <el-table-column label="Date" width="140px">
                 <template slot-scope="scope">
                   {{ formatDateWith(scope.row.date, 'MMM D, HH:mm') }}
                 </template>
               </el-table-column>
-              <el-table-column label="Amount" width="140px">
+              <el-table-column label="Amount" width="150px">
                 <template slot-scope="scope">
-                  <div class="row__amount">
-                    <span>{{ scope.row.amount.from }} BTC</span>
-                    <span>{{ scope.row.amount.to }} ETH</span>
-                  </div>
+                  {{ (scope.row.from === 'you' ? '−' : '+') + Number(scope.row.amount) + ' ' + wallets.find(w => w.assetId = scope.row.assetId).asset}}
                 </template>
               </el-table-column>
-              <el-table-column label="Description" width="290px">
+              <el-table-column label="Address" min-width="120" show-overflow-tooltip>
+                <template slot-scope="scope">
+                  {{ scope.row.to === 'notary' ? 'Withdrawal ' : '' }}to {{ scope.row.to === 'notary' ? scope.row.message : scope.row.to }}
+                </template>
+              </el-table-column>
+              <el-table-column label="Description" min-width="200">
                 <template slot-scope="scope">
                   <div>
-                    {{ `${scope.row.description.substr(0, 100)}...` }}
+                    <div v-if="scope.row.from === 'notary' || scope.row.to === 'notary'"></div>
+                    <div v-else>{{ scope.row.message }}</div>
                   </div>
                 </template>
               </el-table-column>
-              <el-table-column label="Address" width="110px">
+              <el-table-column label="Signs" min-width="50">
                 <template slot-scope="scope">
-                  <span>{{ scope.row.address }}</span>
+                  {{ scope.row.signatures }} / {{ accountQuorum }}
                 </template>
               </el-table-column>
-              <el-table-column>
+              <el-table-column min-width="130px">
                 <template slot-scope="scope">
                   <div>
                     <el-button
@@ -44,7 +57,7 @@
                       size="medium"
                       type="primary"
                       plain>
-                      Confirm
+                      Add signatures
                     </el-button>
                   </div>
                 </template>
@@ -59,41 +72,25 @@
 
 <script>
 import dateFormat from '@/components/mixins/dateFormat'
-import { mapActions } from 'vuex'
+import numberFormat from '@/components/mixins/numberFormat'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
   name: 'transaction-page',
   mixins: [
-    dateFormat
+    dateFormat,
+    numberFormat
   ],
   data () {
     return {
-      mockData: [{
-        date: 1535100895476,
-        amount: {
-          from: '0.0048',
-          to: '0.3223'
-        },
-        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-        address: '0x905f948341241519128'
-      }, {
-        date: 1535100895476,
-        amount: {
-          from: '0.0148',
-          to: '0.7223'
-        },
-        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-        address: '0x333f948341241519128'
-      }, {
-        date: 1535100895476,
-        amount: {
-          from: '0.0048',
-          to: '0.3223'
-        },
-        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-        address: '0x583f948341241519128'
-      }]
     }
+  },
+  computed: {
+    ...mapGetters([
+      'allPendingTransactions',
+      'wallets',
+      'accountQuorum'
+    ])
   },
   created () {
     this.$store.dispatch('getPendingTransactions')

--- a/src/components/Transactions/TransactionPage.vue
+++ b/src/components/Transactions/TransactionPage.vue
@@ -95,11 +95,13 @@ export default {
     ])
   },
   created () {
-    this.$store.dispatch('getPendingTransactions')
+    this.getPendingTransactions()
   },
   methods: {
     ...mapActions([
-      'openApprovalDialog'
+      'openApprovalDialog',
+      'signPendingTransaction',
+      'getPendingTransactions'
     ]),
     onSignPendingTransaction (txStoreId) {
       this.openApprovalDialog()
@@ -107,7 +109,7 @@ export default {
           if (!privateKeys) return
           this.isSending = true
 
-          return this.$store.dispatch('signPendingTransaction', {
+          return this.signPendingTransaction({
             privateKeys,
             txStoreId
           })
@@ -116,7 +118,7 @@ export default {
                 message: 'Transaction succesfuly finalised and sent!',
                 type: 'success'
               })
-              this.$store.dispatch('getPendingTransactions')
+              this.getPendingTransactions()
             })
             .catch(err => {
               console.error(err)

--- a/src/components/Transactions/TransactionPage.vue
+++ b/src/components/Transactions/TransactionPage.vue
@@ -53,10 +53,11 @@
                 <template slot-scope="scope">
                   <div>
                     <el-button
-                      @click="openApprovalDialog()"
+                      @click="onSubmitTransferForm(row.scope.id)"
                       size="medium"
                       type="primary"
-                      plain>
+                      plain
+                    >
                       Add signatures
                     </el-button>
                   </div>
@@ -98,7 +99,36 @@ export default {
   methods: {
     ...mapActions([
       'openApprovalDialog'
-    ])
+    ]),
+    onSubmitTransferForm (txStoreId) {
+      this.openApprovalDialog()
+        .then(privateKeys => {
+          if (!privateKeys) return
+          this.isSending = true
+
+          return this.$store.dispatch('signPendingTransaction', {
+            privateKeys,
+            txStoreId
+          })
+            .then(() => {
+              this.$message({
+                message: 'Transaction succesfuly finalised and sent!',
+                type: 'success'
+              })
+              this.fetchWallet()
+              this.resetTransferForm()
+              this.transferFormVisible = false
+            })
+            .catch(err => {
+              console.error(err)
+              this.$alert(err.message, 'Transaction signing error', {
+                type: 'error'
+              })
+            })
+        })
+        .finally(() => { this.isSending = false })
+    }
+
   }
 }
 </script>

--- a/src/store/Account.js
+++ b/src/store/Account.js
@@ -203,7 +203,7 @@ const mutations = {
   [types.GET_ACCOUNT_TRANSACTIONS_REQUEST] (state) {},
 
   [types.GET_ACCOUNT_TRANSACTIONS_SUCCESS] (state, transactions) {
-    Vue.set(state, 'rawTransactions', transactions)
+    state.rawTransactions = transactions
   },
 
   [types.GET_ACCOUNT_TRANSACTIONS_FAILURE] (state, err) {

--- a/src/store/Account.js
+++ b/src/store/Account.js
@@ -44,7 +44,7 @@ function initialState () {
     rawAssetTransactions: {},
     rawUnsignedTransactions: [],
     rawTransactions: [],
-    rawPengingTransactions: [],
+    rawPendingTransactions: null,
     assets: [],
     connectionError: null
   }
@@ -80,6 +80,13 @@ const getters = {
       state.rawAssetTransactions[assetId],
       state.accountId
     )
+  },
+
+  allPendingTransactions: (state) => {
+    return state.rawPendingTransactions ? getTransferAssetsFrom(
+      state.rawPendingTransactions.toObject().transactionsList,
+      state.accountId
+    ).filter(tx => tx.from === 'you') : []
   },
 
   waitingSettlements () {
@@ -195,7 +202,7 @@ const mutations = {
   [types.GET_ACCOUNT_TRANSACTIONS_REQUEST] (state) {},
 
   [types.GET_ACCOUNT_TRANSACTIONS_SUCCESS] (state, transactions) {
-    state.rawTransactions = transactions
+    Vue.set(state, 'rawTransactions', transactions)
   },
 
   [types.GET_ACCOUNT_TRANSACTIONS_FAILURE] (state, err) {
@@ -215,7 +222,7 @@ const mutations = {
   [types.GET_PENDING_TRANSACTIONS_REQUEST] (state) {},
 
   [types.GET_PENDING_TRANSACTIONS_SUCCESS] (state, transactions) {
-    state.rawPengingTransactions = transactions
+    state.rawPendingTransactions = transactions
   },
 
   [types.GET_PENDING_TRANSACTIONS_FAILURE] (state, err) {
@@ -354,7 +361,7 @@ const actions = {
     commit(types.GET_PENDING_TRANSACTIONS_REQUEST)
 
     return irohaUtil.getPendingTransactions()
-      .then(res => commit(types.GET_PENDING_TRANSACTIONS_SUCCESS, res))
+      .then(transactions => commit(types.GET_PENDING_TRANSACTIONS_SUCCESS, transactions))
       .catch(err => {
         commit(types.GET_PENDING_TRANSACTIONS_FAILURE, err)
         throw err

--- a/src/store/Account.js
+++ b/src/store/Account.js
@@ -32,7 +32,8 @@ const types = flow(
   'TRANSFER_ASSET',
   'CREATE_SETTLEMENT',
   'ACCEPT_SETTLEMENT',
-  'REJECT_SETTLEMENT'
+  'REJECT_SETTLEMENT',
+  'SIGN_PENDING'
 ])
 
 function initialState () {
@@ -237,6 +238,14 @@ const mutations = {
     handleError(state, err)
   },
 
+  [types.SIGN_PENDING_REQUEST] (state) {},
+
+  [types.SIGN_PENDING_SUCCESS] (state) {},
+
+  [types.SIGN_PENDING_FAILURE] (state, err) {
+    handleError(state, err)
+  },
+
   [types.CREATE_SETTLEMENT_REQUEST] (state) {},
 
   [types.CREATE_SETTLEMENT_SUCCESS] (state) {},
@@ -377,6 +386,19 @@ const actions = {
       })
       .catch(err => {
         commit(types.TRANSFER_ASSET_FAILURE, err)
+        throw err
+      })
+  },
+
+  signPendingTransaction ({ commit, state }, { privateKeys, txStoreId }) {
+    commit(types.SIGN_PENDING_REQUEST)
+
+    return irohaUtil.signPendingTransaction(privateKeys, state.rawPendingTransactions.getTransactionsList()[txStoreId])
+      .then(() => {
+        commit(types.SIGN_PENDING_SUCCESS)
+      })
+      .catch(err => {
+        commit(types.SIGN_PENDING_FAILURE, err)
         throw err
       })
   },

--- a/src/util/iroha/commands.js
+++ b/src/util/iroha/commands.js
@@ -37,6 +37,22 @@ function command (
 }
 
 /**
+ * signPendingTransaction: sign transaction with more keys and send.
+ * @param {Array.<String>} privateKeys
+ * @param {Object} transaction
+ */
+function signPendingTransaction (privateKeys = [], transaction, timeoutLimit = DEFAULT_TIMEOUT_LIMIT) {
+  debug('starting signPendingTransaction...')
+  let txToSend = signWithArrayOfKeys(transaction, privateKeys)
+
+  let txClient = new CommandServiceClient(
+    cache.nodeIp
+  )
+
+  return sendTransactions([txToSend], txClient, timeoutLimit)
+}
+
+/**
  * createAccount
  * {@link https://iroha.readthedocs.io/en/latest/api/commands.html#cresate-account createAccount - Iroha docs}
  * @param {Array.<String>} privateKeys
@@ -197,7 +213,6 @@ function createSettlement (senderPrivateKeys, senderAccountId = cache.username, 
   receiverTx = txHelper.addMeta(receiverTx, { creatorAccountId: receiverAccountId, receiverQuorum })
 
   const batchArray = txHelper.addBatchMeta([senderTx, receiverTx], 0)
-
   batchArray[0] = signWithArrayOfKeys(batchArray[0], senderPrivateKeys)
 
   return sendTransactions(batchArray, txClient, timeoutLimit)
@@ -223,6 +238,7 @@ function sendTransactions (txs, txClient, timeoutLimit) {
       reject(new Error('please check IP address OR your internet connection'))
     }, timeoutLimit)
 
+    // Sending even 1 transaction to listTorii is absolutely ok and valid.
     txClient.listTorii(txList, (err, data) => {
       clearTimeout(timer)
 
@@ -283,5 +299,6 @@ export {
   addAssetQuantity,
   createSettlement,
   setAccountDetail,
-  setAccountQuorum
+  setAccountQuorum,
+  signPendingTransaction
 }

--- a/src/util/iroha/commands.js
+++ b/src/util/iroha/commands.js
@@ -22,77 +22,18 @@ function command (
   quorum = 1,
   timeoutLimit = DEFAULT_TIMEOUT_LIMIT
 ) {
-  let txClient, txHash
-
-  return new Promise((resolve, reject) => {
-    let txToSend = txHelper.addMeta(tx, {
-      creatorAccountId: cache.username,
-      quorum
-    })
-
-    txToSend = signWithArrayOfKeys(txToSend, privateKeys)
-    txHash = txHelper.hash(txToSend)
-
-    txClient = new CommandServiceClient(
-      cache.nodeIp
-    )
-
-    debug('submitting transaction...')
-    debug('peer ip:', cache.nodeIp)
-    debug('parameters:', JSON.stringify(txToSend.getPayload(), null, '  '))
-    debug('txhash:', Buffer.from(txHash).toString('hex'))
-    debug('')
-
-    const timer = setTimeout(() => {
-      txClient.$channel.close()
-      reject(new Error('please check IP address OR your internet connection'))
-    }, timeoutLimit)
-
-    txClient.torii(txToSend, (err, data) => {
-      clearTimeout(timer)
-
-      if (err) {
-        return reject(err)
-      }
-
-      debug('submitted transaction successfully!')
-      resolve()
-    })
+  let txToSend = txHelper.addMeta(tx, {
+    creatorAccountId: cache.username,
+    quorum
   })
-    .then(() => {
-      debug('opening transaction status stream...')
 
-      return new Promise((resolve, reject) => {
-        let statuses = []
+  txToSend = signWithArrayOfKeys(txToSend, privateKeys)
 
-        let request = new TxStatusRequest()
-        request.setTxHash(txHash)
+  let txClient = new CommandServiceClient(
+    cache.nodeIp
+  )
 
-        let stream = txClient.statusStream(request)
-        stream.on('data', function (response) {
-          statuses.push(response)
-        })
-
-        stream.on('end', function (end) {
-          // Throw error if Iroha closed connection without sending status responses
-          if (statuses.length === 0) return reject(new Error('Problems with notary service. Please try again later.'))
-
-          const last = statuses[statuses.length - 1].getTxStatus()
-
-          const lastStatusName = getProtoEnumName(
-            TxStatus,
-            'iroha.protocol.TxStatus',
-            last
-          )
-
-          if (lastStatusName !== 'COMMITTED' && lastStatusName !== 'MST_PENDING') {
-            return reject(new Error(`Your transaction wasn't commited: expected=COMMITED or MST_PENDING, actual=${lastStatusName}`))
-          }
-
-          resolve()
-        })
-      })
-    })
+  return sendTransactions([txToSend], txClient, timeoutLimit)
 }
 
 /**
@@ -245,7 +186,9 @@ function addSignatory (privateKeys, accountId, publicKey, accountQuorum) {
 function createSettlement (senderPrivateKeys, senderAccountId = cache.username, senderQuorum = 1, senderAssetId, senderAmount, description, receiverAccountId, receiverQuorum = 1, receiverAssetId, receiverAmount, timeoutLimit = DEFAULT_TIMEOUT_LIMIT) {
   debug('starting createSettlement...')
 
-  let txClient
+  let txClient = new CommandServiceClient(
+    cache.nodeIp
+  )
 
   let senderTx = txHelper.addCommand(txHelper.emptyTransaction(), 'transferAsset', { srcAccountId: senderAccountId, destAccountId: receiverAccountId, assetId: senderAssetId, description, amount: senderAmount })
   senderTx = txHelper.addMeta(senderTx, { creatorAccountId: senderAccountId, senderQuorum })
@@ -257,30 +200,30 @@ function createSettlement (senderPrivateKeys, senderAccountId = cache.username, 
 
   batchArray[0] = signWithArrayOfKeys(batchArray[0], senderPrivateKeys)
 
-  const senderTxHash = txHelper.hash(batchArray[0])
-  const receiverTxHash = txHelper.hash(batchArray[1])
+  return sendTransactions(batchArray, txClient, timeoutLimit)
+}
 
-  const batch = txHelper.createTxListFromArray(batchArray)
+function sendTransactions (txs, txClient, timeoutLimit) {
+  const hashes = txs.map(x => txHelper.hash(x))
+  const txList = txHelper.createTxListFromArray(txs)
 
   return new Promise((resolve, reject) => {
-    debug('submitting transaction...')
+    debug('submitting transactions...')
     debug('peer ip:', cache.nodeIp)
-    debug('parameters sender:', JSON.stringify(senderTx.getPayload(), null, '  '))
-    debug('parameters receiver:', JSON.stringify(receiverTx.getPayload(), null, '  '))
-    debug('senderTxHash:', Buffer.from(senderTxHash).toString('hex'))
-    debug('receiverTxHash:', Buffer.from(receiverTxHash).toString('hex'))
-    debug('')
-
-    txClient = new CommandServiceClient(
-      cache.nodeIp
+    txs.forEach(x =>
+      debug('parameters sender:', JSON.stringify(x.getPayload(), null, '  '))
     )
+    hashes.forEach(x =>
+      debug('receiverTxHash:', Buffer.from(x).toString('hex'))
+    )
+    debug('')
 
     const timer = setTimeout(() => {
       txClient.$channel.close()
       reject(new Error('please check IP address OR your internet connection'))
     }, timeoutLimit)
 
-    txClient.listTorii(batch, (err, data) => {
+    txClient.listTorii(txList, (err, data) => {
       clearTimeout(timer)
 
       if (err) {
@@ -296,7 +239,7 @@ function createSettlement (senderPrivateKeys, senderAccountId = cache.username, 
         debug('opening transaction status stream...')
 
         // Status requests promises
-        let requests = [senderTxHash, receiverTxHash].map(hash => new Promise((resolve, reject) => {
+        let requests = hashes.map(hash => new Promise((resolve, reject) => {
           let statuses = []
 
           let request = new TxStatusRequest()
@@ -319,7 +262,7 @@ function createSettlement (senderPrivateKeys, senderAccountId = cache.username, 
             x
           ) : null)
 
-          statuses.every(x => x === 'MST_PENDING') ? resolve() : reject(new Error(`Your transaction wasn't commited: expected=MST_PENDING, MST_PENDING actual=${statuses[0]}, ${statuses[1]}`))
+          statuses.every(x => x === 'MST_PENDING' || x === 'COMMITTED') ? resolve() : reject(new Error(`Your transaction wasn't commited: expected: MST_PENDING or COMMITED actual=${statuses}`))
         })
       })
     })

--- a/src/util/iroha/queries.js
+++ b/src/util/iroha/queries.js
@@ -215,8 +215,8 @@ function getPendingTransactions () {
         return reject(new Error(`Query response error: expected=TRANSACTIONS_RESPONSE , actual=${responseName}`))
       }
 
-      const transactions = response.getTransactionsResponse().toObject().transactionsList
-
+      const transactions = response.getTransactionsResponse()
+      console.log(transactions)
       debug('transactions', transactions)
 
       resolve(transactions)

--- a/src/util/iroha/queries.js
+++ b/src/util/iroha/queries.js
@@ -216,7 +216,7 @@ function getPendingTransactions () {
       }
 
       const transactions = response.getTransactionsResponse()
-      console.log(transactions)
+      console.log(transactions.getTransactionsList())
       debug('transactions', transactions)
 
       resolve(transactions)

--- a/src/util/iroha/queries.js
+++ b/src/util/iroha/queries.js
@@ -216,7 +216,6 @@ function getPendingTransactions () {
       }
 
       const transactions = response.getTransactionsResponse()
-      console.log(transactions.getTransactionsList())
       debug('transactions', transactions)
 
       resolve(transactions)

--- a/src/util/store-util.js
+++ b/src/util/store-util.js
@@ -36,15 +36,17 @@ export function getTransferAssetsFrom (transactions, accountId, settlements = []
 
   transactions.forEach(t => {
     const { commandsList, createdTime } = t.payload.reducedPayload
+    const signaturesAmount = t.signaturesList.length
 
-    commandsList.forEach(c => {
+    commandsList.forEach((c, idx) => {
       if (!c.transferAsset) return
 
       const {
         amount,
         destAccountId,
         srcAccountId,
-        description
+        description,
+        assetId
       } = c.transferAsset
 
       const tx = {
@@ -58,7 +60,11 @@ export function getTransferAssetsFrom (transactions, accountId, settlements = []
           .otherwise(x => x),
         amount: amount,
         date: createdTime,
-        message: description
+        message: description,
+
+        signatures: signaturesAmount,
+        id: idx,
+        assetId
       }
 
       const settlement = findSettlementOfTransaction(settlements, c.transferAsset)

--- a/tests/unit/store/Account.spec.js
+++ b/tests/unit/store/Account.spec.js
@@ -97,7 +97,7 @@ describe('Account store', () => {
         rawAssetTransactions: randomObject(),
         rawUnsignedTransactions: [randomObject()],
         rawTransactions: [randomObject()],
-        rawPengingTransactions: [randomObject()],
+        rawPendingTransactions: [randomObject()],
         assets: randomObject(),
         connectionError: new Error()
       }
@@ -110,7 +110,7 @@ describe('Account store', () => {
         rawAssetTransactions: {},
         rawUnsignedTransactions: [],
         rawTransactions: [],
-        rawPengingTransactions: [],
+        rawPendingTransactions: null,
         assets: [],
         connectionError: null
       }
@@ -377,7 +377,7 @@ describe('Account store', () => {
       it('should return transformed transactions', () => {
         const state = { rawAssetTransactions: MOCK_ASSET_TRANSACTIONS }
         const result = getters.getTransactionsByAssetId(state)('omisego#test')
-        const expectedKeys = ['amount', 'date', 'from', 'to', 'message']
+        const expectedKeys = ['amount', 'date', 'from', 'to', 'message', 'id', 'assetId', 'signatures']
 
         expect(result)
           .to.be.an('array')


### PR DESCRIPTION
## Description
Now accounts with mulitsig (test@notary) can create transactions with not enough signatures and sign them later

## How to check
1. `yarn && yarn serve`
2. login to `test@notary`, create transfer, enter only 1 key.
3. go to "transactions" page and sign this transaction with second key.
4. Check that transfer was successful on the "wallet" page.

## Known issues
1. Transaction doesn't disappear from pending and you can sign and send it again – problem in Iroha
2. No indication about current signatures of transaction – will be done in the next sprint.
3. If someone sends you a settlement, part of it will be displayed here – will be fixed in the "settlement" task.
4. When you create a transaction with only 1 key, it displays "transaction was send" - we will fix it later.