### PR TITLE
D3-392 | Fixing several dashboard issues

### DIFF
--- a/src/components/Dashboard/Charts/DonutChart.vue
+++ b/src/components/Dashboard/Charts/DonutChart.vue
@@ -57,6 +57,9 @@ export default {
       this.onReady()
     }
   },
+  created () {
+    this.onReady()
+  },
   methods: {
     onReady (instance, ECharts) {
       this.chart.series[0].data = this.data.map(a => ({

--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -105,9 +105,10 @@ export default {
     }
   },
 
-  mounted () {
+  created () {
     this._adjustYAxisWidthDebounced = debounce(500)(this.adjustYAxisWidth.bind(this))
     window.addEventListener('resize', this._adjustYAxisWidthDebounced)
+    this.onReady()
   },
 
   beforeDestroy () {

--- a/src/components/Dashboard/Charts/LineChartTable.vue
+++ b/src/components/Dashboard/Charts/LineChartTable.vue
@@ -69,6 +69,9 @@ export default {
       this.onReady()
     }
   },
+  created () {
+    this.onReady()
+  },
   methods: {
     onReady (instance, ECharts) {
       this.chart.tooltip.formatter = data => {

--- a/src/components/Dashboard/DashboardDonutChart.vue
+++ b/src/components/Dashboard/DashboardDonutChart.vue
@@ -49,7 +49,6 @@ export default {
   computed: {
     filterPortfolio () {
       const portfolio = this.portfolio.filter(t => t.percent !== 0)
-      console.log(portfolio)
       const sortedPortfolio = [...portfolio].sort((a, b) => b.percent - a.percent)
       const firstTokens = sortedPortfolio.slice(0, 5)
       const otherTokens = sortedPortfolio.slice(5, sortedPortfolio.length - 1)

--- a/src/components/Dashboard/DashboardDonutChart.vue
+++ b/src/components/Dashboard/DashboardDonutChart.vue
@@ -48,7 +48,9 @@ export default {
   },
   computed: {
     filterPortfolio () {
-      const sortedPortfolio = [...this.portfolio].sort((a, b) => b.percent - a.percent)
+      const portfolio = this.portfolio.filter(t => t.percent !== 0)
+      console.log(portfolio)
+      const sortedPortfolio = [...portfolio].sort((a, b) => b.percent - a.percent)
       const firstTokens = sortedPortfolio.slice(0, 5)
       const otherTokens = sortedPortfolio.slice(5, sortedPortfolio.length - 1)
       const otherTokensPercent = otherTokens.reduce((t1, t2) => t1 + t2.percent, 0)
@@ -59,7 +61,11 @@ export default {
         percent: otherTokensPercent,
         price: otherTokensPrice
       }
-      return [...firstTokens, otherToken]
+      if (portfolio.length > 5) {
+        return [...firstTokens, otherToken]
+      } else {
+        return [...firstTokens]
+      }
     }
   }
 }

--- a/src/components/Dashboard/DashboardPage.vue
+++ b/src/components/Dashboard/DashboardPage.vue
@@ -1,5 +1,6 @@
 <template>
-  <el-container v-if="wallets.length || dashboardLoading" v-loading.fullscreen.lock="dashboardLoading">
+  <el-container v-if="dashboardLoading" v-loading.fullscreen="dashboardLoading" />
+  <el-container v-else-if="hasNonEmptyWallets">
     <el-main class="column-fullheight">
       <el-row class="card_margin-bottom">
         <el-col :span="16">
@@ -52,7 +53,7 @@ export default {
       dashboardChartHeight: 0
     }
   },
-  mounted () {
+  created () {
     this.$store.dispatch('loadDashboard')
     window.addEventListener('resize', debounce(500)(this.getDashboardChartHeight))
     this.getDashboardChartHeight()
@@ -73,7 +74,10 @@ export default {
       'portfolioHistory',
       'portfolioList',
       'dashboardLoading'
-    ])
+    ]),
+    hasNonEmptyWallets () {
+      return this.portfolioList.length && !this.portfolioList.filter(t => t.price === 0).length
+    }
   }
 }
 </script>

--- a/src/components/Dashboard/DashboardPage.vue
+++ b/src/components/Dashboard/DashboardPage.vue
@@ -76,7 +76,7 @@ export default {
       'isDashboardLoading'
     ]),
     hasNonEmptyWallets () {
-      return this.portfolioList.length && !this.portfolioList.filter(t => t.price === 0).length
+      return this.portfolioList.length && (this.portfolioList.length > this.portfolioList.filter(t => t.price === 0).length)
     }
   }
 }

--- a/src/components/Dashboard/DashboardPage.vue
+++ b/src/components/Dashboard/DashboardPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-container v-if="dashboardLoading" v-loading.fullscreen="dashboardLoading" />
+  <el-container v-if="isDashboardLoading" v-loading.fullscreen="isDashboardLoading" />
   <el-container v-else-if="hasNonEmptyWallets">
     <el-main class="column-fullheight">
       <el-row class="card_margin-bottom">
@@ -73,7 +73,7 @@ export default {
       'portfolioPercent',
       'portfolioHistory',
       'portfolioList',
-      'dashboardLoading'
+      'isDashboardLoading'
     ]),
     hasNonEmptyWallets () {
       return this.portfolioList.length && !this.portfolioList.filter(t => t.price === 0).length

--- a/src/components/Dashboard/DashboardTable.vue
+++ b/src/components/Dashboard/DashboardTable.vue
@@ -119,7 +119,8 @@ export default {
       return this.portfolio.filter(crypto => {
         const isName = includes(crypto.name.toLowerCase(), this.filterInput.toLowerCase())
         const isAsset = includes(crypto.asset.toLowerCase(), this.filterInput.toLowerCase())
-        return isName || isAsset
+        const notEmpty = crypto.price !== 0
+        return (isName || isAsset) && notEmpty
       })
     },
     sortedPortfolio () {

--- a/src/components/Dashboard/DashboardTable.vue
+++ b/src/components/Dashboard/DashboardTable.vue
@@ -3,10 +3,6 @@
     <div class="card-content_header">
       <el-row class="card-content_header-row">
         <el-col :span="24">
-          <!-- <el-input
-            placeholder="Search"
-            prefix-icon="el-icon-search"
-            v-model="filterInput"/> -->
           <div class="searchbar">
             <div class="searchbar__prefix">
               <fa-icon icon="search" class="searchbar__icon" />

--- a/src/components/Signup.vue
+++ b/src/components/Signup.vue
@@ -28,9 +28,11 @@
             type="primary"
             @click="onClickAddAddressToWhiteList"
             :loading="isLoading"
-            style="margin-left: 10px"
+            style="margin-left: 10px; float: right;"
           >
-            ADD
+            <span v-if="!isLoading">
+              ADD
+            </span>
           </el-button>
         </el-form-item>
         <el-form-item v-if="form.whitelist.length">

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -150,23 +150,23 @@
                 <div class="transaction_details">
                   <div v-if="scope.row.settlement">
                     <el-row>
-                      <el-col :span="6">{{ formatDateLong(scope.row.settlement.date) }}</el-col>
-                      <el-col :span="6" class="transaction_details-amount">
+                      <el-col :span="4">{{ formatDateLong(scope.row.settlement.date) }}</el-col>
+                      <el-col :span="2" class="transaction_details-amount">
                         <p>- {{ scope.row.settlement.offer_amount }} {{ scope.row.settlement.offer_asset }}</p>
                         <p>+ {{ scope.row.settlement.request_amount }} {{ scope.row.settlement.request_asset }}</p>
                       </el-col>
-                      <el-col :span="6">{{ scope.row.settlement.message }}</el-col>
-                      <el-col :span="6">{{ scope.row.settlement.to }}</el-col>
+                      <el-col>{{ scope.row.settlement.message }}</el-col>
+                      <el-col :span="2">{{ scope.row.settlement.to }}</el-col>
                     </el-row>
                   </div>
                   <div v-else>
                     <el-row>
-                      <el-col :span="6">{{ formatDateLong(scope.row.date) }}</el-col>
-                      <el-col :span="6" class="transaction_details-amount">
+                      <el-col :span="4">{{ formatDateLong(scope.row.date) }}</el-col>
+                      <el-col :span="2" class="transaction_details-amount">
                         {{scope.row.from === 'you' ? '−' : '+'}}{{ scope.row.amount }}
                       </el-col>
-                      <el-col :span="6">{{ scope.row.message.length ? scope.row.message : 'Message not provided...' }}</el-col>
-                      <el-col :span="6">{{ scope.row.to === 'you' ? scope.row.from : scope.row.to }}</el-col>
+                      <el-col>{{ scope.row.message.length ? scope.row.message : 'Message not provided...' }}</el-col>
+                      <el-col :span="2">{{ scope.row.to === 'you' ? scope.row.from : scope.row.to }}</el-col>
                     </el-row>
                   </div>
                 </div>
@@ -184,21 +184,21 @@
                 </span>
               </template>
             </el-table-column>
-            <el-table-column prop="message" label="Description" min-width="200">
+            <el-table-column prop="message" label="Description" min-width="200" show-overflow-tooltip>
               <template slot-scope="scope">
-                <div v-if="scope.row.settlement">Part of a settlement <fa-icon icon="exchange-alt" /></div>
-                <div v-if="scope.row.from === 'notary' || scope.row.to === 'notary'"></div>
-                <div v-else>{{ scope.row.message }}</div>
+                <p v-if="scope.row.settlement">Part of a settlement <fa-icon icon="exchange-alt" /></p>
+                <p v-if="scope.row.from === 'notary' || scope.row.to === 'notary'"></p>
+                <p v-else>{{ scope.row.message }}</p>
               </template>
             </el-table-column>
             <el-table-column label="Address" min-width="120" show-overflow-tooltip>
               <template slot-scope="scope">
-                <div v-if="scope.row.from === 'you'">
+                <span v-if="scope.row.from === 'you'">
                   {{ scope.row.to === 'notary' ? 'Withdrawal' : '' }} to {{ scope.row.to === 'notary' ? scope.row.message : scope.row.to }}
-                </div>
-                <div v-else>
+                </span>
+                <span v-else>
                   {{ scope.row.from === 'notary' ? 'Deposit' : '' }} from {{ scope.row.from === 'notary' ? scope.row.message : scope.row.from }}
-                </div>
+                </span>
               </template>
             </el-table-column>
           </el-table>

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -376,7 +376,8 @@ export default {
       'cryptoInfo',
       'settingsView',
       'ethWalletAddress',
-      'withdrawWalletAddresses'
+      'withdrawWalletAddresses',
+      'getTransactionsByAssetId'
     ]),
 
     wallet () {
@@ -388,7 +389,7 @@ export default {
     transactions () {
       if (!this.wallet) return []
 
-      return this.$store.getters.getTransactionsByAssetId(this.wallet.assetId)
+      return this.getTransactionsByAssetId(this.wallet.assetId)
     },
 
     displayPrecision () {

--- a/src/components/Wallets/WalletMenuItem.vue
+++ b/src/components/Wallets/WalletMenuItem.vue
@@ -45,7 +45,7 @@ export default {
 
 .card.router-link-active {
   background: #f4f4f4;
-  padding-bottom: 14px;
+  padding-bottom: 13px;
   border-bottom: 2px solid #2d2d2d;
 }
 

--- a/src/store/Dashboard.js
+++ b/src/store/Dashboard.js
@@ -258,7 +258,7 @@ const actions = {
   },
   async getPriceByFilter ({ commit, getters }, data) {
     const wallets = getters.wallets.filter(w => Number(w.amount) !== 0)
-    const crypto = (wallets.length && !data.crypto) ? wallets[0].asset : data.crypto
+    const crypto = (wallets.length && !data.crypto) ? getters.portfolioChart.crypto || wallets[0].asset : data.crypto
     if (crypto) {
       commit(types.SELECT_CHART_CRYPTO, crypto)
     }

--- a/src/store/Dashboard.js
+++ b/src/store/Dashboard.js
@@ -108,7 +108,7 @@ const getters = {
   connectionError (state) {
     return state.connectionError
   },
-  dashboardLoading (state) {
+  isDashboardLoading (state) {
     return state.isLoading
   }
 }

--- a/src/store/Dashboard.js
+++ b/src/store/Dashboard.js
@@ -257,7 +257,8 @@ const actions = {
       })
   },
   async getPriceByFilter ({ commit, getters }, data) {
-    const crypto = (getters.wallets.length && !data.crypto) ? getters.wallets[0].asset : data.crypto
+    const wallets = getters.wallets.filter(w => Number(w.amount) !== 0)
+    const crypto = (wallets.length && !data.crypto) ? wallets[0].asset : data.crypto
     if (crypto) {
       commit(types.SELECT_CHART_CRYPTO, crypto)
     }

--- a/tests/e2e/support/command.js
+++ b/tests/e2e/support/command.js
@@ -17,7 +17,6 @@ Cypress.Commands.add('login', (keyPath) => {
   cy.upload_file(keyPath, 'input.el-upload__input')
   cy.get('form > div:nth-child(3) input')
     .type(Cypress.env('IROHA')).should('have.value', Cypress.env('IROHA'))
-  console.log(Cypress.env())
   cy.get('.login-button-container > div > button').click()
   cy.url().should('be.not.eq', `${Cypress.config('baseUrl')}/#/login`)
 })

--- a/tests/unit/store/Dashboard.spec.js
+++ b/tests/unit/store/Dashboard.spec.js
@@ -403,10 +403,10 @@ describe('Dashboard store', () => {
         expect(result).to.be.a('null')
       })
     })
-    describe('dashboardLoading', () => {
+    describe('isDashboardLoading', () => {
       it('should return false', () => {
         const state = { isLoading: false }
-        const result = getters.dashboardLoading(state)
+        const result = getters.isDashboardLoading(state)
         expect(result).to.be.false
       })
     })


### PR DESCRIPTION
# Description
Right now, an entire list of all the assets Is shown to the user. The task is to check on Iroha side what wallets are non-empty and display only that information. Also need to fix several issues that was send in discord.

# Bugs
![image](https://user-images.githubusercontent.com/16295803/46146183-d32c0700-c26a-11e8-83f1-38425e771bd8.png)
![image](https://user-images.githubusercontent.com/16295803/46146201-df17c900-c26a-11e8-9913-bfc7d86fdf66.png)


# Works done
- [x] Now empty wallets don't shown on dashboard page
- [x] Fixed charts loading
- [x] Fixed padding of active item on wallets page

# How to check
1. `yarn` to install all dependencies
1. `yarn serve` and open the app.