### PR TITLE
[D3-276][D3-393] Portfolio's time range selection and tooltip

### DIFF
--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -98,9 +98,9 @@ export default {
   methods: {
     onReady (instance, ECharts) {
       this.chart.tooltip.formatter = data => {
-        const value = data[0].value
+        const value = parseFloat(data[0].value.toFixed(2)).toLocaleString()
         const time = this.formatDate(data[0].data.time * 1000)
-        return `${time}<br/>${value.toFixed(2)} ${this.currencySymbol}`
+        return `${time}<br/>${value} ${this.currencySymbol}`
       }
       this.chart.xAxis.data = this.data.map(i => this.convertTime(i.time))
       this.chart.series[0].data = this.data.map(i => {

--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -11,6 +11,7 @@
 <script>
 import format from 'date-fns/format'
 import currencySymbol from '@/components/mixins/currencySymbol'
+import dateFormat from '@/components/mixins/dateFormat'
 
 export default {
   name: 'line-chart-portfolio',
@@ -18,33 +19,63 @@ export default {
     data: {
       type: Array,
       required: true
+    },
+    filter: {
+      type: String,
+      required: true
     }
   },
   mixins: [
-    currencySymbol
+    currencySymbol,
+    dateFormat
   ],
   data () {
     return {
       chart: {
         grid: {
-          width: '104%',
-          height: '100%',
-          top: '0%',
-          left: '-2%'
+          width: '85%',
+          height: 140,
+          top: 10,
+          left: '15%',
+          bottom: 0
         },
         tooltip: {
           trigger: 'axis'
         },
         xAxis: {
-          show: false,
-          data: []
+          data: [],
+          axisLine: {
+            show: false
+          },
+          axisTick: {
+            show: false
+          },
+          axisLabel: {
+            inside: true,
+            showMinLabel: false
+          },
+          z: 100
         },
         yAxis: {
-          show: false
+          axisLine: {
+            show: false
+          },
+          axisTick: {
+            show: false
+          },
+          axisLabel: {
+            showMinLabel: false,
+            showMaxLabel: false
+          },
+          splitLine: {
+            show: false
+          }
         },
         series: [{
           type: 'line',
-          symbol: 'none',
+          symbolSize: 10,
+          showSymbol: false,
+          hoverAnimation: false,
           itemStyle: {
             color: '#000000'
           },
@@ -68,15 +99,24 @@ export default {
     onReady (instance, ECharts) {
       this.chart.tooltip.formatter = data => {
         const value = data[0].value
-        const date = data[0].axisValue
-        return `${date}<br/>${value.toFixed(2)} ${this.currencySymbol}`
+        const time = this.formatDate(data[0].data.time * 1000)
+        return `${time}<br/>${value.toFixed(2)} ${this.currencySymbol}`
       }
-      this.chart.xAxis.data = this.data.map(i => this.convertDate(i.time))
-      this.chart.series[0].data = this.data.map(i => i.sum)
+      this.chart.xAxis.data = this.data.map(i => this.convertTime(i.time))
+      this.chart.series[0].data = this.data.map(i => {
+        return { value: i.sum, time: i.time }
+      })
     },
-    convertDate (num) {
+    convertTime (num) {
+      const filterFormat = {
+        '1Y': 'MMM\'YY',
+        '1M': 'DD MMM',
+        '1W': 'ddd',
+        '1D': 'HH:mm',
+        '1H': 'HH:mm'
+      }
       const date = new Date(num * 1000)
-      return format(date, 'DD MMMM')
+      return format(date, filterFormat[this.filter])
     }
   }
 }
@@ -84,7 +124,7 @@ export default {
 
 <style scoped>
 .echarts {
-  height: 190px;
+  height: 150px;
   width: 100%;
 }
 </style>

--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -36,6 +36,8 @@ export default {
           width: '85%',
           height: 140,
           top: 10,
+          // TODO: adjust the width of yAxis to the number of digits of labels
+          // it varies depending on time ranges or fiat currencies.
           left: '15%',
           bottom: 0
         },

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -22,8 +22,9 @@
           <div
             v-for="(value, index) in daysLabels"
             :key="index"
-            :class="['1W' !== value ? 'chart_time-filter' : 'chart_time-filter selected']"
-            >
+            :class="[portfolioFilter !== value ? 'chart_time-filter' : 'chart_time-filter selected']"
+            @click="selectLabel(value)"
+          >
             <p class="chart_time-filter_value">{{ value }}</p>
           </div>
           <div class="chart_header-divider"></div>
@@ -35,6 +36,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { lazyComponent } from '@router'
 import numberFormat from '@/components/mixins/numberFormat'
 import currencySymbol from '@/components/mixins/currencySymbol'
@@ -63,12 +65,21 @@ export default {
       daysLabels: ['1H', '1D', '1W', '1M', '1Y']
     }
   },
+  computed: {
+    ...mapGetters([
+      'portfolioFilter'
+    ])
+  },
   methods: {
     classTrend (value) {
       let className = 'neutraltrend'
       if (value > 0) className = 'uptrend'
       if (value < 0) className = 'downtrend'
       return className
+    },
+
+    selectLabel (label) {
+      this.$store.dispatch('getPortfolioHistory', { filter: label })
     }
   }
 }

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -9,9 +9,11 @@
           <p class="portfolio_current-price_value" justify="center">{{ price.value | formatNumberLong }} {{ currencySymbol }}</p>
         </div>
         <div class="portfolio_diff-price">
-          <p :class="classTrend(price.diff)">
-            {{ price.diff | formatNumberShort }} {{ currencySymbol }} ({{price.percent | formatPercent }})
-          </p>
+          <el-tooltip :content="`${parseFloat(price.diff).toLocaleString()} ${currencySymbol}`">
+            <p :class="classTrend(price.diff)">
+              {{ price.diff | formatNumberShort }} {{ currencySymbol }} ({{price.percent | formatPercent }})
+            </p>
+          </el-tooltip>
         </div>
       </el-col>
       <el-col :span="1">

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -6,10 +6,12 @@
           <p class="portfolio_header-title">My Portfolio</p>
         </div>
         <div class="portfolio_current-price">
-          <p class="portfolio_current-price_value" justify="center">{{ price.value | formatNumberLong }} {{ currencySymbol }}</p>
+          <el-tooltip :content="`current price: ${parseFloat(price.value).toLocaleString()} ${currencySymbol}`">
+            <p class="portfolio_current-price_value" justify="center">{{ price.value | formatNumberLong }} {{ currencySymbol }}</p>
+          </el-tooltip>
         </div>
         <div class="portfolio_diff-price">
-          <el-tooltip :content="`${parseFloat(price.diff).toLocaleString()} ${currencySymbol}`">
+          <el-tooltip :content="`difference from the previous day: ${parseFloat(price.diff).toLocaleString()} ${currencySymbol}`">
             <p :class="classTrend(price.diff)">
               {{ price.diff | formatNumberShort }} {{ currencySymbol }} ({{price.percent | formatPercent }})
             </p>

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -29,7 +29,7 @@
           </div>
           <div class="chart_header-divider"></div>
         </div>
-        <line-chart-portfolio :data="chartData"/>
+        <line-chart-portfolio :data="chartData" :filter="portfolioFilter" />
       </el-col>
     </el-card>
   </el-row>

--- a/src/main.js
+++ b/src/main.js
@@ -61,7 +61,8 @@ import {
   MessageBox,
   Dropdown,
   DropdownMenu,
-  DropdownItem
+  DropdownItem,
+  Tooltip
 } from 'element-ui'
 import lang from 'element-ui/lib/locale/lang/en'
 import locale from 'element-ui/lib/locale'
@@ -101,6 +102,7 @@ Vue.use(Main)
 Vue.use(Dropdown)
 Vue.use(DropdownMenu)
 Vue.use(DropdownItem)
+Vue.use(Tooltip)
 Vue.use(Loading.directive)
 Vue.prototype.$alert = MessageBox.alert
 Vue.prototype.$message = Message

--- a/src/util/cryptoApi-axios-util.js
+++ b/src/util/cryptoApi-axios-util.js
@@ -35,9 +35,10 @@ const loadHistoryByLabels = axios => (currencies, settings, options = {}) => {
     }
   }
   const search = dateFilter[options.filter]
+  const endpoint = 'data/' + (search ? search.url : 'histoday')
   const history = currencies.map(crypto => {
     return axios
-      .get(`data/${search.url}`, {
+      .get(endpoint, {
         params: {
           fsym: crypto.asset,
           tsym: currentFiat,

--- a/src/util/cryptoApi-axios-util.js
+++ b/src/util/cryptoApi-axios-util.js
@@ -8,13 +8,40 @@ let axiosAPI = axios.create({
 
 const loadHistoryByLabels = axios => (currencies, settings, options = {}) => {
   const currentFiat = settings.fiat
+  const dateFilter = {
+    'ALL': {
+      url: 'histoday',
+      time: 730
+    },
+    '1Y': {
+      url: 'histoday',
+      time: 365
+    },
+    '1M': {
+      url: 'histoday',
+      time: 30
+    },
+    '1W': {
+      url: 'histoday',
+      time: 7
+    },
+    '1D': {
+      url: 'histohour',
+      time: 24
+    },
+    '1H': {
+      url: 'histominute',
+      time: 60
+    }
+  }
+  const search = dateFilter[options.filter]
   const history = currencies.map(crypto => {
     return axios
-      .get('data/histoday', {
+      .get(`data/${search.url}`, {
         params: {
           fsym: crypto.asset,
           tsym: currentFiat,
-          limit: options.limit || 30,
+          limit: options.limit || search.time,
           toTs: options.toTs
         }
       })

--- a/tests/unit/store/Dashboard.spec.js
+++ b/tests/unit/store/Dashboard.spec.js
@@ -40,7 +40,8 @@ describe('Dashboard store', () => {
             percent: 555
           },
           assetsPercentage: [{}, {}, {}],
-          assetsHistory: [{}, {}, {}]
+          assetsHistory: [{}, {}, {}],
+          filter: 'ALL'
         },
         assetList: [{}, {}, {}],
         assetChart: {
@@ -59,7 +60,8 @@ describe('Dashboard store', () => {
             percent: 0
           },
           assetsPercentage: [],
-          assetsHistory: []
+          assetsHistory: [],
+          filter: '1W'
         },
         assetList: [],
         assetChart: {
@@ -274,16 +276,15 @@ describe('Dashboard store', () => {
             crypto: randomArrayElement(['BTC', 'ETH', 'XRP'])
           }
         }
-        await actions.getPortfolioHistory({ commit, getters })
+        const filter = randomArrayElement(['1Y', '1M', '1W', '1D', '1H'])
+        await actions.getPortfolioHistory({ commit, getters }, { filter })
 
-        const response = commit.secondCall.args[1]
+        const response = commit.thirdCall.args[1]
 
         expect(commit.args).to.deep.equal([
+          [types.SELECT_PORTFOLIO_FILTER, filter],
           [types.GET_PORTFOLIO_HISTORY_REQUEST],
-          [types.GET_PORTFOLIO_HISTORY_SUCCESS, response],
-          [types.GET_PORTFOLIO_FULL_PRICE],
-          [types.GET_PORTFOLIO_PRICE_PERCENTAGE, getters.wallets],
-          [types.GET_PORTFOLIO_PRICE_LIST, getters.wallets]
+          [types.GET_PORTFOLIO_HISTORY_SUCCESS, response]
         ])
       })
     })


### PR DESCRIPTION
# Description
* [x] Make DashboardPortfolio's range selector available.
    * [x] Think another action to update DashboardPortfolio's line chart because existing getPriceByFilter affects DashboardChart's line chart.
* [x] Update the line chart's style to Zeplin
    * [x] Show x/yAxis
    * [x] Adjust the width of yAxis to the number of digits of its labels
* [x] Add tooltips like a wallet page to figures to show its unit and its exact value. ElementUI's tooltip would be better than a title attribute in that it enables copy & paste.

# Screenshots
Tooltip

![screen shot 2018-09-26 at 15 52 56](https://user-images.githubusercontent.com/1365915/46062290-4b7bc500-c1a4-11e8-916d-43aa33509439.png)

Chart (RUB & 1Y)

![screen shot 2018-09-26 at 14 50 03](https://user-images.githubusercontent.com/1365915/46059726-7f062180-c19b-11e8-862c-0e2e381899cd.png)

Chart (EUR & 1H)

![screen shot 2018-09-26 at 14 51 07](https://user-images.githubusercontent.com/1365915/46059759-a0670d80-c19b-11e8-8ad5-aa73d67ce815.png)

# Known issues
I tried to place xAxis inside as Zeplin does but it overlaps the line chart and yAxis 🤔 

![d3](https://user-images.githubusercontent.com/1365915/46061551-05bdfd00-c1a2-11e8-8bca-b0546c382198.png)

# How to check
1. `yarn server` and open the app.
2. Check the portfolio at the top of the dashboard page.