### PR TITLE
A report until today

### DIFF
--- a/tests/unit/fixtures/report.json
+++ b/tests/unit/fixtures/report.json
@@ -10,6 +10,10 @@
     },
     "priceFiatList": [
       {
+        "date": 1530403200000,
+        "price": 0.0023
+      },
+      {
         "date": 1530489600000,
         "price": 0.0021
       },
@@ -197,9 +201,9 @@
       {
         "date": "Jul. 13, 2018 00:00",
         "dailyIn": "1.73",
-        "dailyInFiat": "823.81",
+        "dailyInFiat": "720.83",
         "dailyOut": "2.61",
-        "dailyOutFiat": "1242.86",
+        "dailyOutFiat": "1087.50",
         "dailyNet": "-0.88"
       },
       {
@@ -219,61 +223,61 @@
         "amount": null,
         "amountFiat": null,
         "balance": "14.28",
-        "balanceFiat": "6800.00"
+        "balanceFiat": "6208.70"
       },
       {
         "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "initial tx",
         "amount": "-1.66",
-        "amountFiat": "-790.48",
+        "amountFiat": "-691.67",
         "balance": "12.62",
-        "balanceFiat": "6009.52"
+        "balanceFiat": "5258.33"
       },
       {
         "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "",
         "amount": "-0.12",
-        "amountFiat": "-57.14",
+        "amountFiat": "-50.00",
         "balance": "12.50",
-        "balanceFiat": "5952.38"
+        "balanceFiat": "5208.33"
       },
       {
         "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "hello",
         "amount": "-0.73",
-        "amountFiat": "-347.62",
+        "amountFiat": "-304.17",
         "balance": "11.77",
-        "balanceFiat": "5604.76"
+        "balanceFiat": "4904.17"
       },
       {
         "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "hi",
         "amount": "-0.10",
-        "amountFiat": "-47.62",
+        "amountFiat": "-41.67",
         "balance": "11.67",
-        "balanceFiat": "5557.14"
+        "balanceFiat": "4862.50"
       },
       {
         "time": "Jul. 13, 2018 07:17",
         "to": "Received",
         "description": "hi",
         "amount": "0.83",
-        "amountFiat": "395.24",
+        "amountFiat": "345.83",
         "balance": "12.50",
-        "balanceFiat": "5952.38"
+        "balanceFiat": "5208.33"
       },
       {
         "time": "Jul. 13, 2018 07:17",
         "to": "Received",
         "description": "hi",
         "amount": "0.90",
-        "amountFiat": "428.57",
+        "amountFiat": "375.00",
         "balance": "13.40",
-        "balanceFiat": "6380.95"
+        "balanceFiat": "5583.33"
       },
       {
         "time": "Jul. 17, 2018 04:41",

--- a/tests/unit/fixtures/report.json
+++ b/tests/unit/fixtures/report.json
@@ -10,10 +10,6 @@
     },
     "priceFiatList": [
       {
-        "date": 1530403200000,
-        "price": 0.0023
-      },
-      {
         "date": 1530489600000,
         "price": 0.0021
       },
@@ -76,10 +72,14 @@
       {
         "date": 1531785600000,
         "price": 0.0022
+      },
+      {
+        "date": 1531872000000,
+        "price": 0.0022
       }
     ],
-    "dateFrom": "Jul. 1, 2018",
-    "dateTo": "Jul. 17, 2018",
+    "dateFrom": "Jul. 1, 2018 00:00",
+    "dateTo": "Jul. 17, 2018 23:59",
     "fiat": "USD",
     "ext": "pdf",
     "transactions": [
@@ -195,15 +195,15 @@
     "startingBalance": "14.28",
     "transactionsByDay": [
       {
-        "date": "Jul. 13",
+        "date": "Jul. 13, 2018 00:00",
         "dailyIn": "1.73",
-        "dailyInFiat": "720.83",
+        "dailyInFiat": "823.81",
         "dailyOut": "2.61",
-        "dailyOutFiat": "1087.50",
+        "dailyOutFiat": "1242.86",
         "dailyNet": "-0.88"
       },
       {
-        "date": "Jul. 17",
+        "date": "Jul. 17, 2018 00:00",
         "dailyIn": "1.44",
         "dailyInFiat": "654.55",
         "dailyOut": "3.46",
@@ -213,70 +213,70 @@
     ],
     "transactionDetails": [
       {
-        "time": "Jul. 1, 00:00",
+        "time": "Jul. 1, 2018 00:00",
         "to": null,
         "description": "Starting Balance",
         "amount": null,
         "amountFiat": null,
         "balance": "14.28",
-        "balanceFiat": "6208.70"
+        "balanceFiat": "6800.00"
       },
       {
-        "time": "Jul. 13, 07:17",
+        "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "initial tx",
         "amount": "-1.66",
-        "amountFiat": "-691.67",
+        "amountFiat": "-790.48",
         "balance": "12.62",
-        "balanceFiat": "5258.33"
+        "balanceFiat": "6009.52"
       },
       {
-        "time": "Jul. 13, 07:17",
+        "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "",
         "amount": "-0.12",
-        "amountFiat": "-50.00",
+        "amountFiat": "-57.14",
         "balance": "12.50",
-        "balanceFiat": "5208.33"
+        "balanceFiat": "5952.38"
       },
       {
-        "time": "Jul. 13, 07:17",
+        "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "hello",
         "amount": "-0.73",
-        "amountFiat": "-304.17",
+        "amountFiat": "-347.62",
         "balance": "11.77",
-        "balanceFiat": "4904.17"
+        "balanceFiat": "5604.76"
       },
       {
-        "time": "Jul. 13, 07:17",
+        "time": "Jul. 13, 2018 07:17",
         "to": "alice@test",
         "description": "hi",
         "amount": "-0.10",
-        "amountFiat": "-41.67",
+        "amountFiat": "-47.62",
         "balance": "11.67",
-        "balanceFiat": "4862.50"
+        "balanceFiat": "5557.14"
       },
       {
-        "time": "Jul. 13, 07:17",
+        "time": "Jul. 13, 2018 07:17",
         "to": "Received",
         "description": "hi",
         "amount": "0.83",
-        "amountFiat": "345.83",
+        "amountFiat": "395.24",
         "balance": "12.50",
-        "balanceFiat": "5208.33"
+        "balanceFiat": "5952.38"
       },
       {
-        "time": "Jul. 13, 07:17",
+        "time": "Jul. 13, 2018 07:17",
         "to": "Received",
         "description": "hi",
         "amount": "0.90",
-        "amountFiat": "375.00",
+        "amountFiat": "428.57",
         "balance": "13.40",
-        "balanceFiat": "5583.33"
+        "balanceFiat": "6380.95"
       },
       {
-        "time": "Jul. 17, 04:41",
+        "time": "Jul. 17, 2018 04:41",
         "to": "alice@test",
         "description": "initial tx",
         "amount": "-1.24",
@@ -285,7 +285,7 @@
         "balanceFiat": "5527.27"
       },
       {
-        "time": "Jul. 17, 04:41",
+        "time": "Jul. 17, 2018 04:41",
         "to": "alice@test",
         "description": "",
         "amount": "-0.08",
@@ -294,7 +294,7 @@
         "balanceFiat": "5490.91"
       },
       {
-        "time": "Jul. 17, 04:41",
+        "time": "Jul. 17, 2018 04:41",
         "to": "alice@test",
         "description": "hello",
         "amount": "-0.20",
@@ -303,7 +303,7 @@
         "balanceFiat": "5400.00"
       },
       {
-        "time": "Jul. 17, 04:41",
+        "time": "Jul. 17, 2018 04:41",
         "to": "alice@test",
         "description": "hi",
         "amount": "-0.84",
@@ -312,7 +312,7 @@
         "balanceFiat": "5018.18"
       },
       {
-        "time": "Jul. 17, 04:41",
+        "time": "Jul. 17, 2018 04:41",
         "to": "Received",
         "description": "",
         "amount": "0.85",
@@ -321,7 +321,7 @@
         "balanceFiat": "5404.55"
       },
       {
-        "time": "Jul. 17, 04:41",
+        "time": "Jul. 17, 2018 04:41",
         "to": "Received",
         "description": "hello",
         "amount": "0.59",
@@ -330,7 +330,7 @@
         "balanceFiat": "5672.73"
       },
       {
-        "time": "Jul. 17, 07:18",
+        "time": "Jul. 17, 2018 07:18",
         "to": "alice@test",
         "description": "",
         "amount": "-1.10",
@@ -339,7 +339,7 @@
         "balanceFiat": "5172.73"
       },
       {
-        "time": "Jul. 17, 23:59",
+        "time": "Jul. 17, 2018 23:59",
         "to": null,
         "description": "Ending Balance",
         "amount": null,


### PR DESCRIPTION
# Description
Make it able to generate a report until today. Use the last minute's close price (i.e. the latest price) as the today's price if today is within the range.

# How to check
1. `yarn serve` and open the app.
2. Go to the report page and try today's report.