### PR TITLE
[D3-412] Handle registration failures

### DIFF
--- a/src/util/notary-util.js
+++ b/src/util/notary-util.js
@@ -16,7 +16,6 @@ const signup = axios => (name, whitelist, publicKey) => {
   return axios
     .post('users', postData)
     .then(({ data }) => ({ response: data }))
-    .catch(error => ({ error }))
 }
 
 export default {

--- a/tests/e2e/integration/auth.spec.js
+++ b/tests/e2e/integration/auth.spec.js
@@ -18,17 +18,15 @@ describe('Test register page', () => {
     cy.contains('Sign Up').should('be.visible')
   })
 
-  it('Register new user', () => {
+  // Signing up should fail because the registration service doesn't work on CI now
+  it('Register new user - failure', () => {
     cy.get('.el-input__inner[name="username"]').type('jasonstatham')
       .should('have.value', 'jasonstatham')
     cy.get('.el-input__inner[name="newAddress"]').type('0x070f9d09370fd7ae3a583fc22a4e9f50ae1bdc78')
       .should('have.value', '0x070f9d09370fd7ae3a583fc22a4e9f50ae1bdc78')
     cy.get('.el-form-item__content > .el-button').contains('ADD').click()
     cy.get('.el-form-item__content > .el-button.fullwidth').click()
-    cy.contains('Download').should('be.visible')
-    cy.contains('Confirm').should('be.disabled')
-    // cy.get('.dialog-footer > .black').click()
-    // cy.contains('Confirm').should('not.be.disabled')
+    cy.get('.el-message-box__title:contains("Sign up error")').should('be.visible')
   })
 
   it.skip('Confirm should redirect to Log in', () => {


### PR DESCRIPTION
# Description
Capture a notary-util's error at a store action layer, not at a notary-util layer, and display the error on an alert.

# How to check
1. `yarn serve` and open the app.
2. Try signing up in the environment that the app has no access to Notary. Signup should fail and an alert should appear.