### PR TITLE
Make the registration service ip changeable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,8 @@ a:hover {
   overflow: scroll;
 }
 
+.el-message,
+.el-message-box,
 .el-popper,
 .el-tooltip__popper, .el-select-dropdown__item {
   font-family: 'IBM Plex Sans', sans-serif;

--- a/src/components/Signup.vue
+++ b/src/components/Signup.vue
@@ -47,6 +47,10 @@
           </el-tag>
         </el-form-item>
         <el-form-item class="signup-button-container">
+          <div class="signup-settings" @click="openNotaryIpPrompt">
+            <fa-icon icon="cog" />
+          </div>
+
           <el-button
             class="fullwidth black"
             type="primary"
@@ -103,6 +107,7 @@
 </template>
 
 <script>
+import { mapState, mapActions } from 'vuex'
 import FileSaver from 'file-saver'
 import inputValidation from '@/components/mixins/inputValidation'
 
@@ -132,11 +137,21 @@ export default {
     }
   },
 
+  computed: {
+    ...mapState({
+      notaryIp: state => state.Account.notaryIp
+    })
+  },
+
   beforeMount () {
     this.updateWhiteListValidationRules()
   },
 
   methods: {
+    ...mapActions([
+      'setNotaryIp'
+    ]),
+
     onSubmit () {
       this.$refs['newAddress'].clearValidate()
       this.$refs['form'].validateField('username', (usernameErrorMessage) => {
@@ -207,6 +222,20 @@ export default {
       this._refreshRules({
         newAddress: { pattern: 'walletAddress', wallets: this.form.whitelist }
       })
+    },
+
+    openNotaryIpPrompt () {
+      this.$prompt('Please input the registration service IP', 'Registration Service IP', {
+        inputValue: this.notaryIp,
+        inputPlaceholder: 'e.g. http://localhost:8083/'
+      })
+        .then(({ value }) => {
+          if (value === this.notaryIp) return
+
+          this.setNotaryIp({ ip: value })
+          this.$message.success(`Registration service IP has been updated`)
+        })
+        .catch(() => {})
     }
   }
 }
@@ -251,5 +280,12 @@ export default {
 
   .el-tag {
     margin-right: 10px;
+  }
+
+  .signup-settings {
+    float: right;
+    cursor: pointer;
+    line-height: 1;
+    margin-bottom: 10px;
   }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -106,7 +106,9 @@ Vue.use(DropdownItem)
 Vue.use(Tooltip)
 Vue.use(Switch)
 Vue.use(Loading.directive)
-Vue.prototype.$alert = MessageBox.alert
+const MsgBox = MessageBox
+Vue.prototype.$prompt = MsgBox.prompt
+Vue.prototype.$alert = MsgBox.alert
 Vue.prototype.$message = Message
 locale.use(lang)
 

--- a/src/store/Account.js
+++ b/src/store/Account.js
@@ -17,7 +17,8 @@ const ASSETS = require('@util/crypto-list.json')
 const types = flow(
   flatMap(x => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE']),
   concat([
-    'RESET'
+    'RESET',
+    'SET_NOTARY_IP'
   ]),
   map(x => [x, x]),
   fromPairs
@@ -41,6 +42,7 @@ function initialState () {
   return {
     accountId: '',
     nodeIp: irohaUtil.getStoredNodeIp(),
+    notaryIp: notaryUtil.baseURL,
     accountInfo: {},
     accountQuorum: 0,
     rawAssetTransactions: {},
@@ -145,6 +147,11 @@ function handleError (state, err) {
 }
 
 const mutations = {
+  [types.SET_NOTARY_IP] (state, ip) {
+    notaryUtil.baseURL = ip
+    state.notaryIp = ip
+  },
+
   [types.RESET] (state) {
     const s = initialState()
 
@@ -274,6 +281,10 @@ const mutations = {
 }
 
 const actions = {
+  setNotaryIp ({ commit }, { ip }) {
+    commit(types.SET_NOTARY_IP, ip)
+  },
+
   signup ({ commit }, { username, whitelist }) {
     commit(types.SIGNUP_REQUEST)
 

--- a/src/util/notary-util.js
+++ b/src/util/notary-util.js
@@ -19,5 +19,7 @@ const signup = axios => (name, whitelist, publicKey) => {
 }
 
 export default {
+  get baseURL () { return axiosNotary.defaults.baseURL },
+  set baseURL (baseURL) { axiosNotary.defaults.baseURL = baseURL },
   signup: signup(axiosNotary)
 }

--- a/tests/unit/store/Account.spec.js
+++ b/tests/unit/store/Account.spec.js
@@ -26,6 +26,7 @@ describe('Account store', () => {
   const MOCK_ASSET_TRANSACTIONS = require('../fixtures/transactions.json')
   const MOCK_TRANSACTIONS = MOCK_ASSET_TRANSACTIONS['omisego#test']
   const MOCK_NODE_IP = 'MOCK_NODE_IP'
+  const MOCK_NOTARY_IP = 'MOCK_NOTARY_IP'
   const MOCK_ACCOUNT_RESPONSE = { accountId: randomAccountId() }
   const MOCK_KEYPAIR = {
     publicKey: randomPublicKey(),
@@ -47,6 +48,7 @@ describe('Account store', () => {
   const notaryUtilMock = {
     _forceFail: false,
     _MOCK_ERROR: new Error(),
+    baseURL: MOCK_NOTARY_IP,
     signup: () => {
       if (notaryUtilMock._forceFail) return new Promise(() => { throw notaryUtilMock._MOCK_ERROR })
       else return Promise.resolve()
@@ -99,6 +101,7 @@ describe('Account store', () => {
       const state = {
         accountId: randomAccountId(),
         nodeIp: randomNodeIp(),
+        notaryIp: randomNodeIp(),
         accountInfo: randomObject(),
         accountQuorum: randomAmountRng(),
         rawAssetTransactions: randomObject(),
@@ -112,6 +115,7 @@ describe('Account store', () => {
       const expectedState = {
         accountId: '',
         nodeIp: MOCK_NODE_IP,
+        notaryIp: MOCK_NOTARY_IP,
         accountInfo: {},
         accountQuorum: 0,
         rawAssetTransactions: {},


### PR DESCRIPTION
# Description
Add getter/setter of baseURL to notary-util and make the registration service ip changeable.
 
![signup](https://user-images.githubusercontent.com/1365915/46195483-6f274280-c33f-11e8-8e70-4b5099d1fb85.gif)

# How to check
1. `yarn serve` and open the app.
2. Go to signup page and try changing the registration service IP. You can see if the IP is changed correctly at the Network pane.