### PR TITLE
D3-552 | Web withdrawal fix - rename notary_red -> notary

### DIFF
--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -337,7 +337,7 @@ import currencySymbol from '@/components/mixins/currencySymbol'
 import inputValidation from '@/components/mixins/inputValidation'
 
 // Notary account for withdrawal.
-const notaryAccount = process.env.VUE_APP_NOTARY_ACCOUNT || 'notary_red@notary'
+const notaryAccount = process.env.VUE_APP_NOTARY_ACCOUNT || 'notary@notary'
 
 export default {
   name: 'wallet',

--- a/src/util/store-util.js
+++ b/src/util/store-util.js
@@ -5,7 +5,7 @@ import uniqWith from 'lodash/fp/uniqWith'
 import sortBy from 'lodash/fp/sortBy'
 import reverse from 'lodash/fp/reverse'
 
-const notaryAccount = process.env.VUE_APP_NOTARY_ACCOUNT || 'notary_red@notary'
+const notaryAccount = process.env.VUE_APP_NOTARY_ACCOUNT || 'notary@notary'
 
 // TODO: To be removed.
 const DUMMY_SETTLEMENTS = require('@/mocks/settlements.json')


### PR DESCRIPTION
# Description
Fix bug with withdrawal after renaming notary_red. 

https://soramitsu.atlassian.net/browse/D3-552

**WARNING**: Test can be conducted only after merging D3-551 task https://github.com/d3ledger/back-office/pull/86

#### Works done
- [x] Rename notary_red to notary. 

# How to check
1. `yarn` to install all dependencies
2. `yarn serve` to run dev server
3. Test withdrawal function