### PR TITLE
D3-685 | Fix validation for amount

### DIFF
--- a/src/components/mixins/inputValidation.js
+++ b/src/components/mixins/inputValidation.js
@@ -39,11 +39,21 @@ set['privateKeyRequired'] = [
 
 const getPrecision = (v) => (v.split('.')[1] || []).length
 
+const checkFirstZero = (v) => {
+  if (!v.length) return true
+
+  if (v[0] !== '0') return true
+  else {
+    return v[0] === '0' && v[1] === '.'
+  }
+}
+
 function checkBalance (maxValue, maxPrecision, asset) {
   return function validator (rule, value, callback, source, options) {
     const errors = []
     if (!asset) errors.push('Please select asset')
     else if (isNaN(Number(value))) errors.push('Invalid amount')
+    else if (!checkFirstZero(value)) errors.push('Please remove zeros')
     else if (value !== null && gt(getPrecision(value))(maxPrecision)) errors.push(`Too big precision, maximum precision is ${maxPrecision}`)
     else if (value !== null && value.length === 0) errors.push('Please input amount')
     else if (gt(Number(value))(Number(maxValue))) errors.push('Current amount is bigger than your available balance')


### PR DESCRIPTION
# Description
Fix validation for amount. A lot of zeros before amount should be invalid

# Screenshot
![image](https://user-images.githubusercontent.com/16295803/50098336-c1844b00-022c-11e9-8aa2-40bb1c5d757c.png)

#### Works done
- [x] Added new validator for zeros

# How to test
1. `yarn` to install dependencies
2. `yarn` to run application
3. Go to wallet and try to transfer `000000.2`