### PR TITLE
Fix | Set iroha node from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ yarn
 #### ENV
 1. `VUE_APP_ETH_NOTARY_URL=http://127.0.0.1:8083` - Used to connect to notary etherium registration service, provide IP of notary. Use this ENV when going to run or build application
 1. `VUE_APP_BTC_NOTARY_URL=http://127.0.0.1:8084` - Used to connect to notary bitcoin registration service, provide IP of notary. Use this ENV when going to run or build application
+1. `VUE_APP_IROHA_URL=http://127.0.0.1:8081` - Used to connect to provide of IP of gRPC IROHA. Use this ENV when going to run or build application
 2. `CYPRESS_IROHA=http://127.0.0.1:8081` - Used to run e2e tests, provide IP of gRPC IROHA.
 3. `CYPRESS_baseUrl=http://127.0.0.1:8080` - Can be used in e2e tests, provide IP of D3 application
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -80,7 +80,7 @@
 
 <script>
 import inputValidation from '@/components/mixins/inputValidation'
-import listOfNodes from '@/data/nodes'
+import { listOfNodes } from '@/data/urls'
 import messageMixin from '@/components/mixins/message'
 
 export default {

--- a/src/data/urls.js
+++ b/src/data/urls.js
@@ -1,5 +1,6 @@
 export const ETH_NOTARY_URL = process.env.VUE_APP_ETH_NOTARY_URL || 'http://localhost:8083'
 export const BTC_NOTARY_URL = process.env.VUE_APP_BTC_NOTARY_URL || 'http://localhost:8084'
+export const IROHA_URL = process.env.VUE_APP_IROHA_URL || 'http://localhost:8081'
 
 export const registrationIPs = [
   {
@@ -9,5 +10,12 @@ export const registrationIPs = [
   {
     'value': BTC_NOTARY_URL,
     'label': 'Bitcoin registartion'
+  }
+]
+
+export const listOfNodes = [
+  {
+    'value': IROHA_URL,
+    'label': 'Node 1'
   }
 ]

--- a/src/data/urls.js
+++ b/src/data/urls.js
@@ -1,6 +1,7 @@
+import listOfNodes from './nodes.json'
 export const ETH_NOTARY_URL = process.env.VUE_APP_ETH_NOTARY_URL || 'http://localhost:8083'
 export const BTC_NOTARY_URL = process.env.VUE_APP_BTC_NOTARY_URL || 'http://localhost:8084'
-export const IROHA_URL = process.env.VUE_APP_IROHA_URL || 'http://localhost:8081'
+export const IROHA_URL = process.env.VUE_APP_IROHA_URL
 
 export const registrationIPs = [
   {
@@ -13,9 +14,11 @@ export const registrationIPs = [
   }
 ]
 
-export const listOfNodes = [
-  {
+if (IROHA_URL) {
+  listOfNodes.unshift({
     'value': IROHA_URL,
-    'label': 'Node 1'
-  }
-]
+    'label': 'Default Node'
+  })
+}
+
+export { listOfNodes }


### PR DESCRIPTION
# Description
Add environment variable to set Iroha url.

#### Works done
- [x] Add environment variable to set Iroha url.
- [x] Set default Iroha url for localhost.

# How to test
1. `yarn` to install all dependencies
2. `yarn serve` to run application
3. Try to set custom iroha url in environment variable VUE_APP_IROHA_URL=