### PR TITLE
D3 686 | Show empty wallet

### DIFF
--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="wallet.assetId">
     <el-row style="margin-bottom: 20px">
       <el-col :xs="24" :lg="{ span: 22, offset: 1 }" :xl="{ span: 20, offset: 2 }">
         <el-row :gutter="20">
@@ -354,12 +354,16 @@
       </el-button>
     </el-dialog>
   </div>
+  <div v-else>
+    <no-assets-card />
+  </div>
 </template>
 
 <script>
 // TODO: Transfer form all assets
 import QrcodeVue from 'qrcode.vue'
 import { mapActions, mapGetters } from 'vuex'
+import { lazyComponent } from '@router'
 import AssetIcon from '@/components/common/AssetIcon'
 import dateFormat from '@/components/mixins/dateFormat'
 import numberFormat from '@/components/mixins/numberFormat'
@@ -388,7 +392,8 @@ export default {
   ],
   components: {
     AssetIcon,
-    QrcodeVue
+    QrcodeVue,
+    NoAssetsCard: lazyComponent('common/NoAssetsCard')
   },
   data () {
     return {
@@ -452,7 +457,9 @@ export default {
   },
 
   created () {
-    this.fetchWallet()
+    if (this.wallet.assetId) {
+      this.fetchWallet()
+    }
   },
 
   beforeMount () {
@@ -596,7 +603,7 @@ export default {
   filters: {
     fitAmount (amount) {
       const withoutZeros = numberFormat.filters.formatPrecision(amount)
-      return withoutZeros.length > 15 ? `${withoutZeros.substr(0, 15)}...` : withoutZeros
+      return withoutZeros.length > 10 ? `${withoutZeros.substr(0, 10)}...` : withoutZeros
     }
   }
 }

--- a/src/components/Wallets/WalletsPage.vue
+++ b/src/components/Wallets/WalletsPage.vue
@@ -41,20 +41,6 @@
         :name="wallet.name"
         :asset="wallet.asset"
       />
-      <wallet-menu-item
-        v-if="btcWalletAddress && !hasBtcWallet"
-        key="btc-empty"
-        walletId="btc-empty"
-        name="Bitcoin"
-        asset="BTC"
-      />
-      <wallet-menu-item
-        v-if="ethWalletAddress && !hasEthWallet"
-        key="eth-empty"
-        walletId="eth-empty"
-        name="Ether"
-        asset="ETH"
-      />
     </el-aside>
     <el-main class="column-fullheight wallet">
       <router-view :key="$route.params.walletId"></router-view>
@@ -108,9 +94,25 @@ export default {
       })
     },
     filteredWallets () {
+      const walletsWithEmpty = [...this.walletsWithFiatPrice]
+      if (this.btcWalletAddress && !this.hasBtcWallet) {
+        walletsWithEmpty.push({
+          id: 'btc-empty',
+          name: 'Bitcoin',
+          asset: 'BTC'
+        })
+      }
+      if (this.ethWalletAddress && !this.hasEthWallet) {
+        walletsWithEmpty.push({
+          id: 'eth-empty',
+          name: 'Ether',
+          asset: 'ETH'
+        })
+      }
+
       return this.search
-        ? this.walletsWithFiatPrice.filter(x => x.name.toLowerCase().indexOf(this.search.toLowerCase()) > -1 || x.asset.toLowerCase().indexOf(this.search.toLowerCase()) > -1)
-        : this.walletsWithFiatPrice
+        ? walletsWithEmpty.filter(x => x.name.toLowerCase().indexOf(this.search.toLowerCase()) > -1 || x.asset.toLowerCase().indexOf(this.search.toLowerCase()) > -1)
+        : walletsWithEmpty
     },
     sortedWallets () {
       const { numeric, key, desc } = this.currentCriterion

--- a/src/components/Wallets/WalletsPage.vue
+++ b/src/components/Wallets/WalletsPage.vue
@@ -41,6 +41,20 @@
         :name="wallet.name"
         :asset="wallet.asset"
       />
+      <wallet-menu-item
+        v-if="btcWalletAddress && !hasBtcWallet"
+        key="btc-empty"
+        walletId="btc-empty"
+        name="Bitcoin"
+        asset="BTC"
+      />
+      <wallet-menu-item
+        v-if="ethWalletAddress && !hasEthWallet"
+        key="eth-empty"
+        walletId="eth-empty"
+        name="Ether"
+        asset="ETH"
+      />
     </el-aside>
     <el-main class="column-fullheight wallet">
       <router-view :key="$route.params.walletId"></router-view>
@@ -81,7 +95,11 @@ export default {
     ...mapGetters({
       wallets: 'wallets',
       portfolioPercent: 'portfolioPercent',
-      currentCriterion: 'walletsSortCriterion'
+      currentCriterion: 'walletsSortCriterion',
+      btcWalletAddress: 'btcWalletAddress',
+      ethWalletAddress: 'ethWalletAddress',
+      hasEthWallet: 'hasEthWallet',
+      hasBtcWallet: 'hasBtcWallet'
     }),
     walletsWithFiatPrice () {
       return this.wallets.map((x, i) => {

--- a/src/components/common/NoAssetsCard.vue
+++ b/src/components/common/NoAssetsCard.vue
@@ -1,13 +1,13 @@
 <template>
   <el-main class="column-fullheight card-wrapper flex-direction-row">
-    <el-card v-if="ethWalletAddress" class="card">You have no assets at the moment. Please transfer your ETH/ERC20 tokens to <span class="monospace bold">{{ ethWalletAddress }}</span> or wait untill someone transfers assets to your account <span class="monospace">{{ accountId }}</span>
+    <el-card v-if="ethWalletAddress && !hasEthWallet" class="card">You have no assets at the moment. Please transfer your ETH/ERC20 tokens to <span class="monospace bold">{{ ethWalletAddress }}</span> or wait untill someone transfers assets to your account <span class="monospace">{{ accountId }}</span>
       <qrcode-vue
         :value="ethWalletAddress"
         :size="270"
         class="qr"
       />
     </el-card>
-    <el-card v-if="btcWalletAddress" class="card">You have no assets at the moment. Please transfer your bitcoins  to <span class="monospace bold">{{ btcWalletAddress }}</span> or wait untill someone transfers assets to your account <span class="monospace">{{ accountId }}</span>
+    <el-card v-if="btcWalletAddress && !hasBtcWallet" class="card">You have no assets at the moment. Please transfer your bitcoins  to <span class="monospace bold">{{ btcWalletAddress }}</span> or wait untill someone transfers assets to your account <span class="monospace">{{ accountId }}</span>
       <qrcode-vue
         :value="btcWalletAddress"
         :size="270"
@@ -37,7 +37,9 @@ export default {
     }),
     ...mapGetters([
       'ethWalletAddress',
-      'btcWalletAddress'
+      'btcWalletAddress',
+      'hasEthWallet',
+      'hasBtcWallet'
     ])
   }
 }

--- a/src/store/Account.js
+++ b/src/store/Account.js
@@ -166,6 +166,14 @@ const getters = {
     return btcWallet ? btcWallet.bitcoin : null
   },
 
+  hasEthWallet (state, getters) {
+    return getters.wallets.some(w => w.domain === 'ethereum')
+  },
+
+  hasBtcWallet (state, getters) {
+    return getters.wallets.some(w => w.domain === 'bitcoin')
+  },
+
   withdrawWalletAddresses (state) {
     const wallet = find('eth_whitelist', state.accountInfo)
     return wallet ? wallet.eth_whitelist.split(',').map(w => w.trim()) : []


### PR DESCRIPTION
# Description
A user cannot browse any other wallets except the first network registered in due to probable frontend bug

https://soramitsu.atlassian.net/browse/D3-686

#### Work done
- [x] Show btc/eth wallet with deposit address when it's empty, but another with money

# How to test
1. Run frontend
2. Register in BTC and ETH network
3. Add any amount of money to one wallet
4. Open wallets page