### PR TITLE
D3 729 | Fix validation message

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -68,7 +68,7 @@
         <el-form-item label="Counterparty" prop="to">
           <el-input v-model="exchangeForm.to" placeholder="Account id" />
         </el-form-item>
-        <el-form-item label="Additional information">
+        <el-form-item label="Additional information" prop="description">
           <el-input
             type="textarea"
             :rows="2"
@@ -176,7 +176,8 @@ export default {
       privateKey: 'repeatingPrivateKey',
       to: 'nameDomain',
       request_amount: 'tokensAmount',
-      offer_amount: 'tokensAmount'
+      offer_amount: 'tokensAmount',
+      description: 'additionalInformation'
     })
   ],
   components: {

--- a/src/components/Signup.vue
+++ b/src/components/Signup.vue
@@ -298,6 +298,7 @@ export default {
 
   .option.left {
     float: left;
+    margin-right: 10px;
   }
 
   .option.right {

--- a/src/components/Wallets/Wallet.vue
+++ b/src/components/Wallets/Wallet.vue
@@ -334,7 +334,7 @@
         <el-form-item label="Counterparty" prop="to">
           <el-input v-model="transferForm.to" placeholder="Account id" />
         </el-form-item>
-        <el-form-item label="Additional information">
+        <el-form-item label="Additional information" prop="description">
           <el-input
             type="textarea"
             :rows="2"
@@ -386,7 +386,8 @@ export default {
     inputValidation({
       to: 'nameDomain',
       amount: 'tokensAmount',
-      wallet: 'walletAddress'
+      wallet: 'walletAddress',
+      description: 'additionalInformation'
     }),
     messageMixin
   ],

--- a/src/components/mixins/inputValidation.js
+++ b/src/components/mixins/inputValidation.js
@@ -10,11 +10,11 @@ const privateKey = {
 const set = {
   name: [
     { required: true, message: 'Please input username', trigger: 'change' },
-    { pattern: /^[a-z_0-9]{1,32}$/, message: 'Username should match [a-Z_0-9]{1,32}', trigger: 'change' }
+    { pattern: /^[a-z_0-9]{1,32}$/, message: 'Username should match [a-z_0-9]{1,32}', trigger: 'change' }
   ],
   nameDomain: [
     { required: true, message: 'Please input username', trigger: 'change' },
-    { pattern: /^[a-z_0-9]{1,32}@[a-z_0-9]{1,9}$/, message: 'Username should match [a-Z_0-9]{1,32}@[a-Z_0-9]{1,9}', trigger: 'change' }
+    { pattern: /^[a-z_0-9]{1,32}@[a-z_0-9]{1,9}$/, message: 'Username should match [a-z_0-9]{1,32}@[a-z_0-9]{1,9}', trigger: 'change' }
   ],
   privateKey: [
     { pattern: privateKey.pattern, message: privateKey.message, trigger: 'change' }
@@ -29,6 +29,9 @@ const set = {
   tokensAmount: [
     { required: true, message: 'Please input amount', trigger: 'change' },
     { pattern: /^(?![0.]+$)\d+(\.\d+)?$/, message: 'Invalid amount', trigger: 'change' }
+  ],
+  additionalInformation: [
+    { pattern: /^.{0,64}$/, message: 'Additional information should not be longer than 64 symbols', trigger: 'change' }
   ]
 }
 

--- a/src/data/urls.js
+++ b/src/data/urls.js
@@ -4,7 +4,7 @@ export const BTC_NOTARY_URL = process.env.VUE_APP_BTC_NOTARY_URL || 'http://loca
 export const registrationIPs = [
   {
     'value': ETH_NOTARY_URL,
-    'label': 'Etherium registration'
+    'label': 'Ethereum registration'
   },
   {
     'value': BTC_NOTARY_URL,


### PR DESCRIPTION
# Description
Invalid representation regular expression during Log in
[a-Z_0-9] should be replaced on [a-z_0-9] if we consider only small letters
Add validation for additional information (no longer than 64 symbols)
Fix type EtherEum
Add space between Bitcoin registration and address.

https://soramitsu.atlassian.net/browse/D3-729
https://soramitsu.atlassian.net/browse/D3-716

### Works done
- [x] Change a-Z to a-z
- [x] Add validation for additional information (no longer than 64 symbols)
- [x] Fix type EtherEum
- [x] Add space between left and right parts of list item in registration and login.

# How to test
1. Run frontend with backend
2. Try to login with login name with uppercases
3. Try to transfer/exchange money with additional information with message more than 64 symbols
4. Change one address in listOfNodes and registrationIPs to longer and check dropdowns in login and registration