### PR TITLE
D3 723 | Fix number format

### DIFF
--- a/src/components/Dashboard/Charts/LineChartPortfolio.vue
+++ b/src/components/Dashboard/Charts/LineChartPortfolio.vue
@@ -12,6 +12,7 @@
 <script>
 import currencySymbol from '@/components/mixins/currencySymbol'
 import dateFormat from '@/components/mixins/dateFormat'
+import numberFormat from '@/components/mixins/numberFormat'
 import debounce from 'lodash/fp/debounce'
 
 export default {
@@ -28,7 +29,8 @@ export default {
   },
   mixins: [
     currencySymbol,
-    dateFormat
+    dateFormat,
+    numberFormat
   ],
   data () {
     const fontFamily = "'IBM Plex Sans', sans-serif"
@@ -117,7 +119,7 @@ export default {
   methods: {
     onReady (instance, ECharts) {
       this.chart.tooltip.formatter = data => {
-        const value = parseFloat(data[0].value.toFixed(2)).toLocaleString()
+        const value = numberFormat.filters.formatNumberLong(data[0].value.toFixed(2))
         const time = this.formatDate(data[0].data.time * 1000)
         return `${time}<br/>${value} ${this.currencySymbol}`
       }

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -6,12 +6,12 @@
           <p class="portfolio_header-title">My Portfolio</p>
         </div>
         <div class="portfolio_current-price">
-          <el-tooltip :content="`current price: ${price.value | formatNumberLong} ${currencySymbol}`" placement="top-start">
+          <el-tooltip :content="`current price: ${formatNumberLongMethod(price.value)} ${currencySymbol}`" placement="top-start">
             <p class="portfolio_current-price_value" justify="center">{{ price.value | formatNumberLong }} {{ currencySymbol }}</p>
           </el-tooltip>
         </div>
         <div class="portfolio_diff-price">
-          <el-tooltip :content="`difference from the previous day: ${price.diff | formatNumberLong} ${currencySymbol}`" placement="top-start">
+          <el-tooltip :content="`difference from the previous day: ${formatNumberLongMethod(price.diff)} ${currencySymbol}`" placement="top-start">
             <p :class="classTrend(price.diff)">
               {{ price.diff | formatNumberShort }} {{ currencySymbol }} ({{price.percent | formatPercent }})
             </p>
@@ -89,6 +89,11 @@ export default {
 
     selectLabel (label) {
       this.$store.dispatch('getPortfolioHistory', { filter: label })
+    },
+
+    formatNumberLongMethod (value) {
+      console.log(numberFormat)
+      return numberFormat.filters.formatNumberLong(value)
     }
   }
 }

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -92,7 +92,6 @@ export default {
     },
 
     formatNumberLongMethod (value) {
-      console.log(numberFormat)
       return numberFormat.filters.formatNumberLong(value)
     }
   }

--- a/src/components/Dashboard/DashboardPortfolio.vue
+++ b/src/components/Dashboard/DashboardPortfolio.vue
@@ -6,12 +6,12 @@
           <p class="portfolio_header-title">My Portfolio</p>
         </div>
         <div class="portfolio_current-price">
-          <el-tooltip :content="`current price: ${parseFloat(price.value).toLocaleString()} ${currencySymbol}`" placement="top-start">
+          <el-tooltip :content="`current price: ${price.value | formatNumberLong} ${currencySymbol}`" placement="top-start">
             <p class="portfolio_current-price_value" justify="center">{{ price.value | formatNumberLong }} {{ currencySymbol }}</p>
           </el-tooltip>
         </div>
         <div class="portfolio_diff-price">
-          <el-tooltip :content="`difference from the previous day: ${parseFloat(price.diff).toLocaleString()} ${currencySymbol}`" placement="top-start">
+          <el-tooltip :content="`difference from the previous day: ${price.diff | formatNumberLong} ${currencySymbol}`" placement="top-start">
             <p :class="classTrend(price.diff)">
               {{ price.diff | formatNumberShort }} {{ currencySymbol }} ({{price.percent | formatPercent }})
             </p>


### PR DESCRIPTION
# Description
When you point to the chart in the portfolio of history, Department integer part from the decimal displays the decimal point. At the same time, in the current price, the separation occurs through the point.
https://soramitsu.atlassian.net/browse/D3-723

# Works done
- [x] Change locale number format to numbro format

# How to Test
1. Run
2. Open portfolio page on russian locale of browser
3. Check tooltips, portfolio value and portfolio history values in chart. They should had same format 