### PR TITLE
D3-812 | Correct regex

### DIFF
--- a/src/components/mixins/inputValidation.js
+++ b/src/components/mixins/inputValidation.js
@@ -3,8 +3,8 @@ import lte from 'lodash/fp/lte'
 import { derivePublicKey } from 'ed25519.js'
 
 const privateKey = {
-  pattern: /^[A-Za-z0-9]{64}$/,
-  message: 'Private key should match [A-Za-z0-9]{64}'
+  pattern: /^[A-Fa-f0-9]{64}$/,
+  message: 'Private key should match [A-Fa-f0-9]{64}'
 }
 
 const set = {


### PR DESCRIPTION
# Description
We have wrong validation for private key

#### Works done
- [x] Changed regex

# How to test
- `yarn` to install dependencies
- `yarn serve` to run application
-  Any private key should be covered by [A-Fa-f0-9]{64}