### PR TITLE
D3-887 | Update to iroha-rc4

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -7,7 +7,7 @@ networks:
 
 services:
   d3-iroha:
-    image: hyperledger/iroha:snapshot_rc3-ba69aa1
+    image: hyperledger/iroha:1.0.0_rc4-hotfix1
     container_name: d3-iroha-${SUBNET}
     depends_on:
       - d3-iroha-postgres

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -7,7 +7,7 @@ networks:
 
 services:
   d3-iroha:
-    image: hyperledger/iroha:1.0.0_rc2-hotfix
+    image: hyperledger/iroha:snapshot_rc3-ba69aa1
     container_name: d3-iroha-${SUBNET}
     depends_on:
       - d3-iroha-postgres

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
 
 services:
   d3-iroha:
-    image: hyperledger/iroha:snapshot_rc3-ba69aa1
+    image: hyperledger/iroha:1.0.0_rc4-hotfix1
     container_name: d3-iroha-${SUBNET}
     depends_on:
       - d3-iroha-postgres

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
 
 services:
   d3-iroha:
-    image: hyperledger/iroha:1.0.0_rc2-hotfix
+    image: hyperledger/iroha:snapshot_rc3-ba69aa1
     container_name: d3-iroha-${SUBNET}
     depends_on:
       - d3-iroha-postgres

--- a/docker/iroha/config.docker
+++ b/docker/iroha/config.docker
@@ -3,9 +3,12 @@
   "torii_port" : 50051,
   "internal_port" : 10001,
   "pg_opt" : "host=d3-iroha-postgres port=5432 user=postgres password=mysecretpassword",
-  "max_proposal_size" : 10,
-  "proposal_delay" : 5000,
-  "vote_delay" : 5000,
+  "max_proposal_size" : 1000,
+  "proposal_delay" : 1000,
+  "vote_delay" : 1000,
   "load_delay" : 5000,
-  "mst_enable" : true
+  "mst_enable" : true,
+  "mst_expiration_time" : 1440,
+  "max_rounds_delay": 10,
+  "stale_stream_max_rounds": 100000
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "element-ui": "^2.4.6",
     "file-saver": "^1.3.8",
     "grpc-web-client": "^0.7.0",
-    "iroha-helpers": "^0.5.5",
+    "iroha-helpers": "^0.6.2",
     "json2csv": "^4.2.1",
     "lodash": "^4.17.10",
     "numbro": "^2.1.0",

--- a/src/data/urls.js
+++ b/src/data/urls.js
@@ -1,5 +1,5 @@
 export const ETH_NOTARY_URL = process.env.VUE_APP_ETH_NOTARY_URL || 'http://localhost:8083'
-export const BTC_NOTARY_URL = process.env.VUE_APP_BTC_NOTARY_URL || 'http://localhost:8084'
+export const BTC_NOTARY_URL = process.env.VUE_APP_BTC_NOTARY_URL || 'http://localhost:8086'
 
 export const registrationIPs = [
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,6 +1306,13 @@
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.1.tgz#f54cad4028213a011c6ecb10eaf2b99dbd4a8496"
 
+"@improbable-eng/grpc-web@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@improbable-eng/grpc-web/-/grpc-web-0.8.0.tgz#c7a9a23560c6667f75cf0e69d5a672aa026683d4"
+  integrity sha512-0K9owV6BGGGVNkGXifsnMAE0Xoy675qqMdr8id4FOILbwxLk9HsJtZKz/zxfRXev1YY9JcAHm4vpZmbr6O+lyw==
+  dependencies:
+    browser-headers "^0.4.0"
+
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz#be7c7846128b88f6a9b1d1261a0ad06eb5c0fdf8"
@@ -5389,11 +5396,12 @@ ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
 
-iroha-helpers@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/iroha-helpers/-/iroha-helpers-0.5.5.tgz#43e15705fa95a001e5d0f1ae280b28fd10798a6f"
-  integrity sha512-64Si1emQ8jS5SAx7ha8pmkCmCA2xyhySIVjQE9f1g2ky442NaQSwpzImT81W21+Var+lseXGn61bJPn4uqM7Nw==
+iroha-helpers@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iroha-helpers/-/iroha-helpers-0.6.2.tgz#33677692b4e693d9f70afe467a9601882c1ca70a"
+  integrity sha512-/yL8Y3PXK3EflQjbMSyyWV6YsCZMvXI4cwHafhQ7ugGa/ms7l9WQ7cGzjRR3s9P90sA1zN7zu4IzdZkOfyNHhA==
   dependencies:
+    "@improbable-eng/grpc-web" "^0.8.0"
     buffer "^5.2.0"
     ed25519.js "^1.3.0"
     google-protobuf "^3.6.1"


### PR DESCRIPTION
# Description
This is a task about to migrate to iroha-rc3. Currently this PR is stoped and we will wait for iroha-rc4.
https://soramitsu.atlassian.net/browse/D3-887