### PR TITLE
D3-1120 | Fix accept\reject of settlements

### DIFF
--- a/src/store/App.js
+++ b/src/store/App.js
@@ -224,8 +224,9 @@ const actions = {
       })
     }
   },
-  closeExchangeDialog ({ commit }) {
+  closeExchangeDialog ({ commit, dispatch }) {
     commit(types.EXCHANGE_DIALOG_CLOSE)
+    dispatch('getAllUnsignedTransactions')
   },
   getOfferToRequestPrice ({ commit, getters }) {
     const offerAsset = getters.exchangeDialogOfferAsset

--- a/src/util/iroha/commands.js
+++ b/src/util/iroha/commands.js
@@ -101,7 +101,7 @@ function createSettlement (senderPrivateKeys, senderAccountId, senderQuorum = 1,
 function acceptSettlement (privateKeys, batchArray, accountId, timeoutLimit = DEFAULT_TIMEOUT_LIMIT) {
   if (!batchArray.length) return
 
-  let txClient = newCommandService()
+  const txClient = newCommandService()
 
   const indexOfUnsigned = cloneDeep(batchArray)
     .map(tx => tx.toObject())
@@ -110,6 +110,8 @@ function acceptSettlement (privateKeys, batchArray, accountId, timeoutLimit = DE
     })
 
   if (indexOfUnsigned === -1) throw new Error('Undefined tx to sign')
+
+  batchArray.forEach(tx => tx.clearSignaturesList())
 
   batchArray[indexOfUnsigned] = signWithArrayOfKeys(batchArray[indexOfUnsigned], privateKeys)
 
@@ -121,7 +123,9 @@ function acceptSettlement (privateKeys, batchArray, accountId, timeoutLimit = DE
 function rejectSettlement (privateKeys, batchArray, timeoutLimit = DEFAULT_TIMEOUT_LIMIT) {
   if (!batchArray.length) return
 
-  let txClient = newCommandService()
+  const txClient = newCommandService()
+
+  batchArray.forEach(tx => tx.clearSignaturesList())
 
   const batch = batchArray.map(b => signWithArrayOfKeys(b, privateKeys))
 


### PR DESCRIPTION
# Description
Added `clearSignaturesList` for correct handling of accepting \ rejecting settlements. We should call `clearSignaturesList` because otherwise transaction will be committed as new one.